### PR TITLE
Fix CreatePost import case

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,7 @@ import Navbar from './components/Navbar';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
-import CreatePost from './pages/createPost';
+import CreatePost from './pages/CreatePost';
 
 function App() {
   return (


### PR DESCRIPTION
## Summary
- fix the import path for `CreatePost` in `frontend/src/App.jsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff79eed9c8324b1f3ae9fe51166eb