### PR TITLE
Add basic testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Redditgram
+
+This project combines a Django REST backend with a React frontend.
+
+## Setup
+
+Install the backend dependencies using the provided helper script:
+
+```bash
+./setup.sh
+```
+
+This script creates a virtual environment in `env/` and installs the packages
+listed in `requirements.txt`.
+
+## Running Tests
+
+Change into the backend directory and run Django's test suite:
+
+```bash
+cd backend
+python manage.py test
+```

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -13,8 +13,9 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 from pathlib import Path
 from decouple import config
 
-API_KEY = config("API_KEY")
-API_SECRET = config("API_SECRET")
+# Provide defaults so tests can run without a local .env file
+API_KEY = config("API_KEY", default="")
+API_SECRET = config("API_SECRET", default="")
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1,3 +1,58 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from rest_framework import status
+from rest_framework.test import APIClient
 
-# Create your tests here.
+from .models import Post
+
+
+class PostAPITestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="testuser", password="testpass"
+        )
+
+    def test_post_list_requires_authentication(self):
+        url = reverse("posts")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_create_post_authenticated(self):
+        url = reverse("posts")
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(url, {"caption": "hello"})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(Post.objects.filter(caption="hello").exists())
+
+
+class RegisterViewTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_register_user(self):
+        url = reverse("register")
+        data = {
+            "username": "newuser",
+            "email": "new@example.com",
+            "password": "pass1234",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(User.objects.filter(username="newuser").exists())
+
+    def test_get_user_info_requires_auth(self):
+        url = reverse("get_user_info")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_get_user_info_authenticated(self):
+        user = User.objects.create_user(
+            username="info_user", password="pass1234", email="i@ex.com"
+        )
+        self.client.force_authenticate(user=user)
+        url = reverse("get_user_info")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["username"], "info_user")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django>=5.2
+djangorestframework>=3.14
+djangorestframework-simplejwt>=5.2
+python-decouple>=3.8
+django-cors-headers>=4.3

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Basic setup script for Redditgram
+# Creates a virtual environment and installs dependencies
+set -e
+
+python3 -m venv env
+. env/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- configure backend settings to fall back to defaults if no `.env` is present
- provide Python requirements for running the backend and tests
- add API tests for registration, authentication and posts
- document setup and how to run the tests
- add a simple `setup.sh` helper script

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_685ffa88855c83249269c0dba72a4559