### PR TITLE
Change API port to 9000

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2,7 +2,7 @@
 import axios from 'axios';
 
 const API = axios.create({
-  baseURL: 'http://127.0.0.1:8000/api',
+  baseURL: 'http://127.0.0.1:9000/api',
 });
 
 API.interceptors.request.use((config) => {
@@ -26,7 +26,7 @@ API.interceptors.response.use(
 
       try {
         const refreshToken = localStorage.getItem('refresh');
-        const res = await axios.post('http://127.0.0.1:8000/api/token/refresh/', {
+        const res = await axios.post('http://127.0.0.1:9000/api/token/refresh/', {
           refresh: refreshToken,
         });
 

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -9,7 +9,7 @@ function Navbar() {
 
   useEffect(() => {
     if (token) {
-      axios.get('http://localhost:8000/api/me/', {
+      axios.get('http://localhost:9000/api/me/', {
         headers: { Authorization: `Bearer ${token}` }
       })
       .then(res => setUser(res.data))

--- a/frontend/src/pages/CreatePost.jsx
+++ b/frontend/src/pages/CreatePost.jsx
@@ -13,7 +13,7 @@ function CreatePost() {
 
     try {
       await axios.post(
-        'http://localhost:8000/api/posts/',
+        'http://localhost:9000/api/posts/',
         { caption },
         {
           headers: {

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -11,7 +11,7 @@ function Login() {
   const handleSubmit = async e => {
     e.preventDefault();
     try {
-      const res = await axios.post('http://localhost:8000/api/token/', form);
+      const res = await axios.post('http://localhost:9000/api/token/', form);
       localStorage.setItem('access', res.data.access);
       localStorage.setItem('refresh', res.data.refresh);
       navigate('/');

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -11,7 +11,7 @@ function Signup() {
   const handleSubmit = async e => {
     e.preventDefault();
     try {
-      await axios.post('http://localhost:8000/api/register/', form);
+      await axios.post('http://localhost:9000/api/register/', form);
       navigate('/login');
     } catch (err) {
       alert('Signup failed');


### PR DESCRIPTION
## Summary
- update API base URL port to 9000 throughout the frontend

## Testing
- `npm run lint` *(fails: cannot fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68729b824860832485bf40ef4f07e6bf