### PR TITLE
Add author-restricted post detail API view

### DIFF
--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,8 +1,14 @@
 from django.urls import path
-from .views import RegisterView, get_user_info, PostListCreateView
+from .views import (
+    RegisterView,
+    get_user_info,
+    PostListCreateView,
+    PostDetailView,
+)
 
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='register'),
     path('me/', get_user_info, name='get_user_info'),
     path('posts/', PostListCreateView.as_view(), name='posts'),
+    path('posts/<int:pk>/', PostDetailView.as_view(), name='post-detail'),
 ]


### PR DESCRIPTION
## Summary
- allow retrieving/updating/deleting a single post
- restrict modifications to the post author via `IsAuthorOrReadOnly`
- expose `/posts/<pk>/` route
- test retrieving, updating and deleting posts

## Testing
- `pytest backend/core/tests.py::PostAPITestCase::test_retrieve_post_authenticated -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687bbcfbdd548324ae59a0b94a1691b0