### PR TITLE
Fix navbar new post link

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -31,12 +31,12 @@ function Navbar() {
           <>
             <span className="text-gray-700">👤 {user.username}</span>
             <button onClick={handleLogout} className="text-red-500 hover:underline">Logout</button>
+            <Link to="/create" className="text-gray-700 hover:text-indigo-600">New Post</Link>
           </>
         ) : (
           <>
             <Link to="/login" className="text-gray-700 hover:text-indigo-600">Login</Link>
             <Link to="/signup" className="text-gray-700 hover:text-indigo-600">Sign Up</Link>
-            <Link to="/create" className="text-gray-700 hover:text-indigo-600">New Post</Link>
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- display "New Post" link only when user is logged in

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `./setup.sh` *(fails: Could not find a version that satisfies the requirement Django>=5.2)*

------
https://chatgpt.com/codex/tasks/task_e_687bbd007df48324a6b02cf2f386d34c