### PR TITLE
Fix README setup and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,34 @@ Install the backend dependencies using the provided helper script:
 This script creates a virtual environment in `env/` and installs the packages
 listed in `requirements.txt`.
 
-=======
-Install the backend dependencies in a virtual environment:
+If you prefer to set up manually, run:
 
 ```bash
 python -m venv env
 source env/bin/activate
 pip install -r requirements.txt
 ```
+
+## Running the backend
+
+Activate the virtual environment and start the Django development server:
+
+```bash
+source env/bin/activate
+cd backend
+python manage.py migrate
+python manage.py runserver
+```
+
+## Running the frontend
+
+Install the Node dependencies and start the React dev server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The application will be available at `http://localhost:5173` by default. Build a
+production bundle with `npm run build` and preview it locally using `npm run preview`.


### PR DESCRIPTION
## Summary
- clean up stray line in README
- document how to run Django backend
- document npm commands for React frontend

## Testing
- `./setup.sh` *(fails: Could not install deps)*
- `python backend/manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_687bbd168fc483248e2e4cea946a0e9b