### PR TITLE
Enable live post notifications

### DIFF
--- a/backend/backend/asgi.py
+++ b/backend/backend/asgi.py
@@ -10,7 +10,15 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
 import os
 
 from django.core.asgi import get_asgi_application
+from channels.routing import ProtocolTypeRouter, URLRouter
+from core.middleware import JWTAuthMiddlewareStack
+import core.routing
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
 
-application = get_asgi_application()
+application = ProtocolTypeRouter({
+    'http': get_asgi_application(),
+    'websocket': JWTAuthMiddlewareStack(
+        URLRouter(core.routing.websocket_urlpatterns)
+    )
+})

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework_simplejwt',
     'corsheaders',
+    'channels',
     'core',
 ]
 
@@ -78,6 +79,7 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'backend.wsgi.application'
+ASGI_APPLICATION = 'backend.asgi.application'
 
 
 # Database
@@ -140,3 +142,10 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Channels configuration
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels.layers.InMemoryChannelLayer',
+    },
+}

--- a/backend/core/consumers.py
+++ b/backend/core/consumers.py
@@ -1,0 +1,19 @@
+import json
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+class NotificationConsumer(AsyncJsonWebsocketConsumer):
+    async def connect(self):
+        user = self.scope.get('user')
+        if user is None or user.is_anonymous:
+            await self.close()
+            return
+        self.group_name = f'user_{user.id}'
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        if hasattr(self, 'group_name'):
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+
+    async def notify(self, event):
+        await self.send_json(event['data'])

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -1,0 +1,28 @@
+from urllib.parse import parse_qs
+from channels.db import database_sync_to_async
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import AccessToken
+
+@database_sync_to_async
+def get_user(token):
+    try:
+        validated = AccessToken(token)
+        user_id = validated['user_id']
+        return get_user_model().objects.get(id=user_id)
+    except Exception:
+        return AnonymousUser()
+
+class JWTAuthMiddleware:
+    def __init__(self, inner):
+        self.inner = inner
+
+    async def __call__(self, scope, receive, send):
+        query = parse_qs(scope.get('query_string', b'').decode())
+        token = query.get('token')
+        scope['user'] = await get_user(token[0]) if token else AnonymousUser()
+        return await self.inner(scope, receive, send)
+
+def JWTAuthMiddlewareStack(inner):
+    from channels.auth import AuthMiddlewareStack
+    return JWTAuthMiddleware(AuthMiddlewareStack(inner))

--- a/backend/core/routing.py
+++ b/backend/core/routing.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import consumers
+
+websocket_urlpatterns = [
+    path('ws/notifications/', consumers.NotificationConsumer.as_asgi()),
+]

--- a/backend/core/signals.py
+++ b/backend/core/signals.py
@@ -2,10 +2,44 @@
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.contrib.auth.models import User
-from .models import Profile
+from .models import Profile, Like, Comment
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 
 @receiver(post_save, sender=User)
 def create_or_update_profile(sender, instance, created, **kwargs):
     if created:
         Profile.objects.create(user=instance)
     instance.profile.save()
+
+@receiver(post_save, sender=Like)
+def send_like_notification(sender, instance, created, **kwargs):
+    if not created:
+        return
+    channel_layer = get_channel_layer()
+    data = {
+        'type': 'notify',
+        'data': {
+            'type': 'like',
+            'post_id': instance.post.id,
+            'by': instance.user.username,
+        }
+    }
+    async_to_sync(channel_layer.group_send)(f'user_{instance.post.author_id}', data)
+
+
+@receiver(post_save, sender=Comment)
+def send_comment_notification(sender, instance, created, **kwargs):
+    if not created:
+        return
+    channel_layer = get_channel_layer()
+    data = {
+        'type': 'notify',
+        'data': {
+            'type': 'comment',
+            'post_id': instance.post.id,
+            'by': instance.author.username,
+            'text': instance.text,
+        }
+    }
+    async_to_sync(channel_layer.group_send)(f'user_{instance.post.author_id}', data)

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
+import { toast } from 'react-toastify';
 
 function Navbar() {
   const navigate = useNavigate();
   const token = localStorage.getItem('access');
   const [user, setUser] = useState(null);
+  const [socket, setSocket] = useState(null);
 
   useEffect(() => {
     if (token) {
@@ -15,12 +17,29 @@ function Navbar() {
       })
       .then(res => setUser(res.data))
       .catch(() => setUser(null));
+
+      const ws = new WebSocket(`ws://localhost:9000/ws/notifications/?token=${token}`);
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === 'like') {
+            toast.info(`Your post ${data.post_id} was liked by ${data.by}`);
+          } else if (data.type === 'comment') {
+            toast.info(`${data.by} commented on your post`);
+          }
+        } catch (err) {
+          console.error('Invalid WS message', err);
+        }
+      };
+      setSocket(ws);
+      return () => ws.close();
     }
   }, [token]);
 
   const handleLogout = () => {
     localStorage.removeItem('access');
     localStorage.removeItem('refresh');
+    if (socket) socket.close();
     navigate('/login');
   };
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework>=3.14
 djangorestframework-simplejwt>=5.2
 python-decouple>=3.8
 django-cors-headers>=4.3
+channels>=4.0


### PR DESCRIPTION
## Summary
- install Django Channels
- configure Channels in settings and ASGI
- add WebSocket routing and JWT auth middleware
- create notification consumer and signals
- open websocket client in Navbar to show toast alerts

## Testing
- `./setup.sh` *(fails: Could not fetch packages)*
- `python backend/manage.py test` *(fails: ModuleNotFoundError: Django)*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885cb26c8408324a20189148f5c9fdc