### PR TITLE
Add email verification & password reset

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -140,3 +140,10 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Email settings
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+DEFAULT_FROM_EMAIL = 'noreply@example.com'
+
+# Base URL for links sent in emails
+FRONTEND_URL = config('FRONTEND_URL', default='http://localhost:5173')

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -11,6 +11,9 @@ from .views import (
     follow_user,
     feed_view,
     search,
+    verify_email,
+    password_reset_request,
+    password_reset_confirm,
 )
 
 urlpatterns = [
@@ -25,4 +28,7 @@ urlpatterns = [
     path('feed/', feed_view, name='feed'),
     path('search/', search, name='search'),
     path('profile/bio/', user_bio_view),
+    path('verify-email/', verify_email, name='verify-email'),
+    path('password-reset/', password_reset_request, name='password-reset'),
+    path('password-reset-confirm/', password_reset_confirm, name='password-reset-confirm'),
 ]

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -19,6 +19,24 @@ from rest_framework import status
 from .models import Post, Comment, Like, Follow
 from .serializers import PostSerializer, ProfileSerializer, CommentSerializer
 from django.http import JsonResponse
+from django.core.mail import send_mail
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
+from django.utils.encoding import force_bytes
+from django.contrib.auth.tokens import default_token_generator
+from django.conf import settings
+
+
+def send_verification_email(user):
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = default_token_generator.make_token(user)
+    link = f"{settings.FRONTEND_URL}/verify-email?uid={uid}&token={token}"
+    send_mail(
+        "Verify your email",
+        f"Click the link to verify your email: {link}",
+        settings.DEFAULT_FROM_EMAIL,
+        [user.email],
+        fail_silently=True,
+    )
 
 @api_view(['GET', 'PUT'])
 @permission_classes([IsAuthenticated])
@@ -77,7 +95,8 @@ class UserSerializer(ModelSerializer):
         extra_kwargs = {'password': {'write_only': True}}
 
     def create(self, validated_data):
-        user = User.objects.create_user(**validated_data)
+        user = User.objects.create_user(is_active=False, **validated_data)
+        send_verification_email(user)
         return user
 
 class RegisterView(generics.CreateAPIView):
@@ -186,5 +205,74 @@ def search(request):
     post_ser = PostSerializer(posts, many=True, context={'request': request})
     user_data = [{'username': u.username} for u in users]
     return Response({'posts': post_ser.data, 'users': user_data})
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def verify_email(request):
+    uid = request.query_params.get('uid')
+    token = request.query_params.get('token')
+    if not uid or not token:
+        return Response({'detail': 'Invalid link.'}, status=400)
+    try:
+        uid = urlsafe_base64_decode(uid).decode()
+        user = User.objects.get(pk=uid)
+    except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+        user = None
+
+    if user and default_token_generator.check_token(user, token):
+        user.is_active = True
+        user.save()
+        return Response({'detail': 'Email verified.'})
+    return Response({'detail': 'Invalid or expired token.'}, status=400)
+
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def password_reset_request(request):
+    email = request.data.get('email')
+    if not email:
+        return Response({'email': 'This field is required.'}, status=400)
+
+    try:
+        user = User.objects.get(email=email)
+    except User.DoesNotExist:
+        # Respond with success even if user does not exist
+        return Response({'detail': 'If an account exists, a password reset email has been sent.'})
+
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = default_token_generator.make_token(user)
+    link = f"{settings.FRONTEND_URL}/reset-password-confirm?uid={uid}&token={token}"
+    send_mail(
+        'Reset your password',
+        f'Click the link to reset your password: {link}',
+        settings.DEFAULT_FROM_EMAIL,
+        [email],
+        fail_silently=True,
+    )
+    return Response({'detail': 'If an account exists, a password reset email has been sent.'})
+
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def password_reset_confirm(request):
+    uid = request.data.get('uid')
+    token = request.data.get('token')
+    password = request.data.get('password')
+
+    if not all([uid, token, password]):
+        return Response({'detail': 'Missing parameters.'}, status=400)
+
+    try:
+        uid = urlsafe_base64_decode(uid).decode()
+        user = User.objects.get(pk=uid)
+    except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+        return Response({'detail': 'Invalid link.'}, status=400)
+
+    if default_token_generator.check_token(user, token):
+        user.set_password(password)
+        user.save()
+        return Response({'detail': 'Password reset successful.'})
+    return Response({'detail': 'Invalid or expired token.'}, status=400)
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,9 @@ import CreatePost from './pages/CreatePost';
 import UserPosts from './pages/UserPosts'; // ← NEW
 import Feed from './pages/Feed';
 import Search from './pages/Search';
+import PasswordResetRequest from './pages/PasswordResetRequest';
+import PasswordResetConfirm from './pages/PasswordResetConfirm';
+import VerifyEmail from './pages/VerifyEmail';
 
 function App() {
   return (
@@ -22,6 +25,9 @@ function App() {
           <Route path="/feed" element={<Feed />} />
           <Route path="/search" element={<Search />} />
           <Route path="/user/:username" element={<UserPosts />} /> {/* ← NEW */}
+          <Route path="/password-reset" element={<PasswordResetRequest />} />
+          <Route path="/reset-password-confirm" element={<PasswordResetConfirm />} />
+          <Route path="/verify-email" element={<VerifyEmail />} />
         </Routes>
       </div>
     </>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -51,6 +51,9 @@ const Login = () => {
       >
         Login
       </button>
+      <div>
+        <a href="/password-reset" className="text-sm text-indigo-600 hover:underline">Forgot password?</a>
+      </div>
     </form>
   );
 };

--- a/frontend/src/pages/PasswordResetConfirm.jsx
+++ b/frontend/src/pages/PasswordResetConfirm.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import axios from 'axios';
+
+const PasswordResetConfirm = () => {
+  const [searchParams] = useSearchParams();
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const uid = searchParams.get('uid');
+    const token = searchParams.get('token');
+    try {
+      await axios.post('http://localhost:9000/api/password-reset-confirm/', {
+        uid,
+        token,
+        password,
+      });
+      setMessage('Password reset successful. You can now log in.');
+    } catch (err) {
+      setMessage('Invalid or expired link.');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        type="password"
+        placeholder="New Password"
+        className="border p-2 w-full"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit" className="bg-indigo-600 text-white px-4 py-2 rounded">
+        Reset Password
+      </button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+};
+
+export default PasswordResetConfirm;

--- a/frontend/src/pages/PasswordResetRequest.jsx
+++ b/frontend/src/pages/PasswordResetRequest.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+const PasswordResetRequest = () => {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await axios.post('http://localhost:9000/api/password-reset/', { email });
+      setMessage('If an account exists for that email, a reset link has been sent.');
+    } catch (err) {
+      setMessage('Something went wrong.');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        type="email"
+        placeholder="Email"
+        className="border p-2 w-full"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <button type="submit" className="bg-indigo-600 text-white px-4 py-2 rounded">
+        Send Reset Link
+      </button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+};
+
+export default PasswordResetRequest;

--- a/frontend/src/pages/VerifyEmail.jsx
+++ b/frontend/src/pages/VerifyEmail.jsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import axios from 'axios';
+
+const VerifyEmail = () => {
+  const [searchParams] = useSearchParams();
+  const [message, setMessage] = useState('Verifying...');
+
+  useEffect(() => {
+    const uid = searchParams.get('uid');
+    const token = searchParams.get('token');
+    axios
+      .get(`http://localhost:9000/api/verify-email/?uid=${uid}&token=${token}`)
+      .then(() => setMessage('Email verified. You can now log in.'))
+      .catch(() => setMessage('Verification failed.'));
+  }, []);
+
+  return <p>{message}</p>;
+};
+
+export default VerifyEmail;


### PR DESCRIPTION
## Summary
- enable console email backend and base URL setting
- send verification emails on registration
- add `verify_email`, `password_reset_request`, and `password_reset_confirm` API endpoints
- implement pages/forms for password reset and email verification in React
- wire routes and link to reset form from login

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885cb2337808324bb52bf2f47e99239