### PR TITLE
Centralize API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,9 @@ npm install
 npm run dev
 ```
 
+The frontend reads the backend URLs from the environment variables
+`VITE_API_BASE_URL` and `VITE_WS_BASE_URL`. If not provided, they default to
+`http://localhost:9000/api` and `ws://localhost:9000` respectively.
+
 The application will be available at `http://localhost:5173` by default. Build a
 production bundle with `npm run build` and preview it locally using `npm run preview`.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,8 +1,9 @@
 // src/api.js
 import axios from 'axios';
+import { API_BASE_URL } from './config';
 
 const API = axios.create({
-  baseURL: 'http://127.0.0.1:9000/api',
+  baseURL: API_BASE_URL,
 });
 
 // 🔐 Add token to every request
@@ -33,7 +34,7 @@ API.interceptors.response.use(
         if (!refreshToken) throw new Error("Missing refresh token");
 
         const res = await axios.post(
-          'http://127.0.0.1:9000/api/token/refresh/',
+          `${API_BASE_URL}/token/refresh/`,
           { refresh: refreshToken }
         );
 

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -2,6 +2,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { toast } from 'react-toastify';
+import { API_BASE_URL, WS_BASE_URL } from '../config';
 
 function Navbar() {
   const navigate = useNavigate();
@@ -11,13 +12,13 @@ function Navbar() {
 
   useEffect(() => {
     if (token) {
-      axios.get('http://localhost:9000/api/me/', {
+      axios.get(`${API_BASE_URL}/me/`, {
         headers: { Authorization: `Bearer ${token}` }
       })
       .then(res => setUser(res.data))
       .catch(() => setUser(null));
 
-      const ws = new WebSocket(`ws://localhost:9000/ws/notifications/?token=${token}`);
+      const ws = new WebSocket(`${WS_BASE_URL}/ws/notifications/?token=${token}`);
       ws.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,2 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:9000/api';
+export const WS_BASE_URL = import.meta.env.VITE_WS_BASE_URL || 'ws://localhost:9000';

--- a/frontend/src/pages/CreatePost.jsx
+++ b/frontend/src/pages/CreatePost.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { API_BASE_URL } from '../config';
 
 function CreatePost() {
   const [caption, setCaption] = useState('');
@@ -13,7 +14,7 @@ function CreatePost() {
 
     try {
       await axios.post(
-        'http://localhost:9000/api/posts/',
+        `${API_BASE_URL}/posts/`,
         { caption },
         {
           headers: {

--- a/frontend/src/pages/PasswordResetConfirm.jsx
+++ b/frontend/src/pages/PasswordResetConfirm.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import axios from 'axios';
+import { API_BASE_URL } from '../config';
 
 const PasswordResetConfirm = () => {
   const [searchParams] = useSearchParams();
@@ -12,7 +13,7 @@ const PasswordResetConfirm = () => {
     const uid = searchParams.get('uid');
     const token = searchParams.get('token');
     try {
-      await axios.post('http://localhost:9000/api/password-reset-confirm/', {
+      await axios.post(`${API_BASE_URL}/password-reset-confirm/`, {
         uid,
         token,
         password,

--- a/frontend/src/pages/PasswordResetRequest.jsx
+++ b/frontend/src/pages/PasswordResetRequest.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 import { toast } from "react-toastify";
+import { API_BASE_URL } from '../config';
 
 const PasswordResetRequest = () => {
   const [email, setEmail] = useState('');
@@ -9,7 +10,7 @@ const PasswordResetRequest = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await axios.post('http://localhost:9000/api/password-reset/', { email });
+      const res = await axios.post(`${API_BASE_URL}/password-reset/`, { email });
       if (res.data.reset_link) {
         window.location.href = res.data.reset_link;
       } else {

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
+import { API_BASE_URL } from '../config';
 
 function Signup() {
   const [form, setForm] = useState({ username: '', email: '', password: '' });
@@ -11,7 +12,7 @@ function Signup() {
   const handleSubmit = async e => {
     e.preventDefault();
     try {
-      await axios.post('http://localhost:9000/api/register/', form);
+      await axios.post(`${API_BASE_URL}/register/`, form);
       navigate('/login');
     } catch (err) {
       alert('Signup failed');

--- a/frontend/src/pages/VerifyEmail.jsx
+++ b/frontend/src/pages/VerifyEmail.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import axios from 'axios';
+import { API_BASE_URL } from '../config';
 
 const VerifyEmail = () => {
   const [searchParams] = useSearchParams();
@@ -10,7 +11,7 @@ const VerifyEmail = () => {
     const uid = searchParams.get('uid');
     const token = searchParams.get('token');
     axios
-      .get(`http://localhost:9000/api/verify-email/?uid=${uid}&token=${token}`)
+      .get(`${API_BASE_URL}/verify-email/?uid=${uid}&token=${token}`)
       .then(() => setMessage('Email verified. You can now log in.'))
       .catch(() => setMessage('Verification failed.'));
   }, []);


### PR DESCRIPTION
## Summary
- add frontend `config.js` for API and WebSocket URLs
- update API helper to use `API_BASE_URL`
- update Navbar and pages to reference config module
- document new environment variables

## Testing
- `npm test` *(fails: Missing script or Jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68865604799483249c70d19005e63e00