### PR TITLE
Fix redux-thunk import

### DIFF
--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,6 +1,6 @@
 // store.js
 import { createStore, applyMiddleware, combineReducers } from "redux";
-import { thunk } from "redux-thunk";
+import thunk from "redux-thunk";
 import { apiMiddleware } from "./apiMiddleware";
 import userReducer from "./reducers/UserReducer";
 


### PR DESCRIPTION
## Summary
- fix redux-thunk import syntax in frontend store

## Testing
- `npm test` *(fails: jest not found)*
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6886560de1608324a0a2d5c91ebbe142