### PR TITLE
Add sidebar components with layout and tests

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
+import LeftSidebar from './components/LeftSidebar';
+import RightSidebar from './components/RightSidebar';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
@@ -13,22 +15,46 @@ import PasswordResetConfirm from './pages/PasswordResetConfirm';
 import VerifyEmail from './pages/VerifyEmail';
 
 function App() {
+  const [showLeft, setShowLeft] = useState(false);
+  const [showRight, setShowRight] = useState(false);
+
   return (
     <>
       <Navbar />
-      <div className="p-4">
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/signup" element={<Signup />} />
-          <Route path="/create" element={<CreatePost />} />
-          <Route path="/feed" element={<Feed />} />
-          <Route path="/search" element={<Search />} />
-          <Route path="/user/:username" element={<UserPosts />} /> {/* ← NEW */}
-          <Route path="/password-reset" element={<PasswordResetRequest />} />
-          <Route path="/reset-password-confirm" element={<PasswordResetConfirm />} />
-          <Route path="/verify-email" element={<VerifyEmail />} />
-        </Routes>
+      {/* Mobile drawer toggles */}
+      <div className="lg:hidden fixed bottom-4 left-4 z-50">
+        <button
+          onClick={() => setShowLeft(true)}
+          className="bg-indigo-600 text-white px-3 py-2 rounded"
+        >
+          Menu
+        </button>
+      </div>
+      <div className="lg:hidden fixed bottom-4 right-4 z-50">
+        <button
+          onClick={() => setShowRight(true)}
+          className="bg-indigo-600 text-white px-3 py-2 rounded"
+        >
+          Menu
+        </button>
+      </div>
+      <div className="flex">
+        <LeftSidebar mobileOpen={showLeft} setMobileOpen={setShowLeft} />
+        <main className="flex-1 p-4">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<Signup />} />
+            <Route path="/create" element={<CreatePost />} />
+            <Route path="/feed" element={<Feed />} />
+            <Route path="/search" element={<Search />} />
+            <Route path="/user/:username" element={<UserPosts />} />
+            <Route path="/password-reset" element={<PasswordResetRequest />} />
+            <Route path="/reset-password-confirm" element={<PasswordResetConfirm />} />
+            <Route path="/verify-email" element={<VerifyEmail />} />
+          </Routes>
+        </main>
+        <RightSidebar mobileOpen={showRight} setMobileOpen={setShowRight} />
       </div>
     </>
   );

--- a/frontend/src/__tests__/sidebars.test.jsx
+++ b/frontend/src/__tests__/sidebars.test.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import LeftSidebar from "../components/LeftSidebar";
+import RightSidebar from "../components/RightSidebar";
+import API from "../api";
+
+jest.mock("../api");
+
+describe("Sidebar components", () => {
+  beforeEach(() => {
+    API.get.mockResolvedValue({ data: { results: [] } });
+  });
+
+  test("renders left sidebar sections", async () => {
+    render(<LeftSidebar mobileOpen={false} setMobileOpen={() => {}} />);
+    expect(screen.getByText(/Trending Posts/i)).toBeInTheDocument();
+    await waitFor(() => expect(API.get).toHaveBeenCalled());
+  });
+
+  test("renders right sidebar sections", async () => {
+    render(<RightSidebar mobileOpen={false} setMobileOpen={() => {}} />);
+    expect(screen.getByText(/My Activity/i)).toBeInTheDocument();
+    await waitFor(() => expect(API.get).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/LeftSidebar.jsx
+++ b/frontend/src/components/LeftSidebar.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import TrendingPosts from "./TrendingPosts";
+import TagList from "./TagList";
+import SuggestedUsers from "./SuggestedUsers";
+
+const LeftSidebar = ({ mobileOpen, setMobileOpen }) => {
+  const content = (
+    <div className="p-4 space-y-6">
+      <TrendingPosts />
+      <TagList />
+      <SuggestedUsers />
+    </div>
+  );
+
+  return (
+    <>
+      <aside className="hidden lg:block w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto">
+        {content}
+      </aside>
+      {mobileOpen && (
+        <div className="lg:hidden fixed inset-0 bg-white z-50 overflow-y-auto">
+          <button
+            onClick={() => setMobileOpen(false)}
+            className="p-2 text-right block ml-auto mr-2 mt-2"
+          >
+            Close
+          </button>
+          {content}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default LeftSidebar;

--- a/frontend/src/components/MyActivity.jsx
+++ b/frontend/src/components/MyActivity.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+import API from "../api";
+
+const MyActivity = () => {
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    API.get("/me/activity/")
+      .then((res) => setItems(res.data.results || res.data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div className="mb-6">
+      <h2 className="font-semibold mb-2">My Activity</h2>
+      <ul className="space-y-1">
+        {items.map((act, idx) => (
+          <li key={act.id || idx} className="text-sm">
+            {act.text || act.action}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MyActivity;

--- a/frontend/src/components/NotificationsPanel.jsx
+++ b/frontend/src/components/NotificationsPanel.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+import API from "../api";
+
+const NotificationsPanel = () => {
+  const [notes, setNotes] = useState([]);
+
+  useEffect(() => {
+    API.get("/me/notifications/")
+      .then((res) => setNotes(res.data.results || res.data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div className="mb-6">
+      <h2 className="font-semibold mb-2">Notifications</h2>
+      <ul className="space-y-1">
+        {notes.map((n, idx) => (
+          <li key={n.id || idx} className="text-sm">
+            {n.text || n.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default NotificationsPanel;

--- a/frontend/src/components/RightSidebar.jsx
+++ b/frontend/src/components/RightSidebar.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import MyActivity from "./MyActivity";
+import SavedPosts from "./SavedPosts";
+import NotificationsPanel from "./NotificationsPanel";
+
+const RightSidebar = ({ mobileOpen, setMobileOpen }) => {
+  const content = (
+    <div className="p-4 space-y-6">
+      <MyActivity />
+      <SavedPosts />
+      <NotificationsPanel />
+    </div>
+  );
+
+  return (
+    <>
+      <aside className="hidden lg:block w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto">
+        {content}
+      </aside>
+      {mobileOpen && (
+        <div className="lg:hidden fixed inset-0 bg-white z-50 overflow-y-auto">
+          <button
+            onClick={() => setMobileOpen(false)}
+            className="p-2 text-right block ml-auto mr-2 mt-2"
+          >
+            Close
+          </button>
+          {content}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default RightSidebar;

--- a/frontend/src/components/SavedPosts.jsx
+++ b/frontend/src/components/SavedPosts.jsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import API from "../api";
+
+const SavedPosts = () => {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    API.get("/me/saved/")
+      .then((res) => setPosts(res.data.results || res.data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div className="mb-6">
+      <h2 className="font-semibold mb-2">Saved Posts</h2>
+      <ul className="space-y-1">
+        {posts.map((post) => (
+          <li key={post.id}>
+            <Link
+              to={`/posts/${post.id}`}
+              className="text-sm text-blue-600 hover:underline"
+            >
+              {post.caption}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SavedPosts;

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import API from "../api";
+
+const SuggestedUsers = () => {
+  const [users, setUsers] = useState([]);
+
+  useEffect(() => {
+    API.get("/users/suggested/")
+      .then((res) => setUsers(res.data.results || res.data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div className="mb-6">
+      <h2 className="font-semibold mb-2">Suggested Users</h2>
+      <ul className="space-y-1">
+        {users.map((user) => (
+          <li key={user.id || user.username}>
+            <Link
+              to={`/user/${user.username}`}
+              className="text-sm text-blue-600 hover:underline"
+            >
+              @{user.username}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SuggestedUsers;

--- a/frontend/src/components/TagList.jsx
+++ b/frontend/src/components/TagList.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+import API from "../api";
+
+const TagList = () => {
+  const [tags, setTags] = useState([]);
+
+  useEffect(() => {
+    API.get("/tags/")
+      .then((res) => setTags(res.data.results || res.data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div className="mb-6">
+      <h2 className="font-semibold mb-2">Trending Tags</h2>
+      <div className="flex flex-wrap gap-2">
+        {tags.map((tag) => (
+          <span key={tag.id || tag} className="text-xs px-2 py-1 bg-gray-200 rounded">
+            #{tag.name || tag}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TagList;

--- a/frontend/src/components/TrendingPosts.jsx
+++ b/frontend/src/components/TrendingPosts.jsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import API from "../api";
+
+const TrendingPosts = () => {
+  const [posts, setPosts] = useState([]);
+
+  useEffect(() => {
+    API.get("/posts/trending/")
+      .then((res) => setPosts(res.data.results || res.data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div className="mb-6">
+      <h2 className="font-semibold mb-2">Trending Posts</h2>
+      <ul className="space-y-1">
+        {posts.map((p) => (
+          <li key={p.id}>
+            <Link
+              to={`/posts/${p.id}`}
+              className="text-sm text-blue-600 hover:underline"
+            >
+              {p.caption}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TrendingPosts;


### PR DESCRIPTION
## Summary
- implement TrendingPosts, TagList and SuggestedUsers components
- implement MyActivity, SavedPosts and NotificationsPanel components
- create LeftSidebar and RightSidebar using the new components
- add sidebars to the main layout with mobile drawers
- add unit tests for sidebar rendering

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688708e569a88324998c53a3a44920d0