### PR TITLE
Add notifications for social actions

### DIFF
--- a/backend/core/signals.py
+++ b/backend/core/signals.py
@@ -2,7 +2,7 @@
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.contrib.auth.models import User
-from .models import Profile, Like, Comment
+from .models import Profile, Like, Comment, Notification, Follow
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 
@@ -26,6 +26,12 @@ def send_like_notification(sender, instance, created, **kwargs):
         }
     }
     async_to_sync(channel_layer.group_send)(f'user_{instance.post.author_id}', data)
+    Notification.objects.create(
+        user=instance.post.author,
+        from_user=instance.user,
+        notification_type='like',
+        post=instance.post,
+    )
 
 
 @receiver(post_save, sender=Comment)
@@ -43,3 +49,29 @@ def send_comment_notification(sender, instance, created, **kwargs):
         }
     }
     async_to_sync(channel_layer.group_send)(f'user_{instance.post.author_id}', data)
+    Notification.objects.create(
+        user=instance.post.author,
+        from_user=instance.author,
+        notification_type='comment',
+        post=instance.post,
+    )
+
+
+@receiver(post_save, sender=Follow)
+def send_follow_notification(sender, instance, created, **kwargs):
+    if not created:
+        return
+    channel_layer = get_channel_layer()
+    data = {
+        'type': 'notify',
+        'data': {
+            'type': 'follow',
+            'by': instance.follower.username,
+        }
+    }
+    async_to_sync(channel_layer.group_send)(f'user_{instance.following_id}', data)
+    Notification.objects.create(
+        user=instance.following,
+        from_user=instance.follower,
+        notification_type='follow',
+    )

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -203,3 +203,40 @@ class AdditionalViewsTestCase(TestCase):
     def test_notifications(self):
         resp = self.client.get(reverse("notifications"))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+
+class SignalNotificationTestCase(TestCase):
+    def setUp(self):
+        self.user1 = User.objects.create_user(username="user1", password="pass")
+        self.user2 = User.objects.create_user(username="user2", password="pass")
+
+    def test_like_creates_notification(self):
+        post = Post.objects.create(author=self.user2, caption="hi")
+        Like.objects.create(post=post, user=self.user1)
+        exists = Notification.objects.filter(
+            user=self.user2,
+            from_user=self.user1,
+            notification_type="like",
+            post=post,
+        ).exists()
+        self.assertTrue(exists)
+
+    def test_comment_creates_notification(self):
+        post = Post.objects.create(author=self.user2, caption="hi")
+        Comment.objects.create(post=post, author=self.user1, text="hey")
+        exists = Notification.objects.filter(
+            user=self.user2,
+            from_user=self.user1,
+            notification_type="comment",
+            post=post,
+        ).exists()
+        self.assertTrue(exists)
+
+    def test_follow_creates_notification(self):
+        Follow.objects.create(follower=self.user1, following=self.user2)
+        exists = Notification.objects.filter(
+            user=self.user2,
+            from_user=self.user1,
+            notification_type="follow",
+        ).exists()
+        self.assertTrue(exists)


### PR DESCRIPTION
## Summary
- create Notification records when users like or comment on a post
- notify followed users when a follow occurs
- tests for notification creation on like, comment, and follow

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6887129e318883248be4b0df1e2f8536