### PR TITLE
Fix notifications panel endpoint and format

### DIFF
--- a/frontend/src/components/NotificationsPanel.jsx
+++ b/frontend/src/components/NotificationsPanel.jsx
@@ -5,10 +5,29 @@ const NotificationsPanel = () => {
   const [notes, setNotes] = useState([]);
 
   useEffect(() => {
-    API.get("/me/notifications/")
+    API.get("/notifications/")
       .then((res) => setNotes(res.data.results || res.data))
       .catch((err) => console.error(err));
   }, []);
+
+  const renderMessage = (n) => {
+    if (!n) return "";
+    const postPart = n.post ? ` on post #${n.post}` : "";
+
+    if (n.notification_type === "comment") {
+      return `${n.from_username} commented on your post${postPart}`;
+    }
+
+    if (n.notification_type === "like") {
+      return `${n.from_username} liked your post${postPart}`;
+    }
+
+    if (n.notification_type === "follow") {
+      return `${n.from_username} followed you`;
+    }
+
+    return n.message || n.text || "";
+  };
 
   return (
     <div className="mb-6">
@@ -16,7 +35,7 @@ const NotificationsPanel = () => {
       <ul className="space-y-1">
         {notes.map((n, idx) => (
           <li key={n.id || idx} className="text-sm">
-            {n.text || n.message}
+            {renderMessage(n)}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- fetch notifications from `/notifications/`
- render messages based on `notification_type`, `from_username` and optional post id

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688712a3d16c83248c3a8cac579bc9e6