### PR TITLE
Implement follow notifications

### DIFF
--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -203,3 +203,16 @@ class AdditionalViewsTestCase(TestCase):
     def test_notifications(self):
         resp = self.client.get(reverse("notifications"))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_follow_creates_notification(self):
+        user3 = User.objects.create_user(username="third", password="pass")
+        url = reverse("follow-user", args=[user3.username])
+        resp = self.client.post(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(
+            Notification.objects.filter(
+                user=user3,
+                from_user=self.user,
+                notification_type="follow",
+            ).exists()
+        )


### PR DESCRIPTION
## Summary
- send follow notifications via signal
- store notification and publish websocket event when following a user
- test that following creates a notification

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688712a9aa44832491764a8d4914f6f2