### PR TITLE
Fix follow notifications and document running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,20 @@ The frontend reads the backend URLs from the environment variables
 
 The application will be available at `http://localhost:5173` by default. Build a
 production bundle with `npm run build` and preview it locally using `npm run preview`.
+
+## Running tests
+
+Run backend tests from the `backend` directory:
+
+```bash
+source env/bin/activate
+cd backend
+python manage.py test
+```
+
+Run frontend tests using `npm`:
+
+```bash
+cd frontend
+npm test
+```

--- a/backend/core/signals.py
+++ b/backend/core/signals.py
@@ -62,11 +62,6 @@ def send_comment_notification(sender, instance, created, **kwargs):
 def send_follow_notification(sender, instance, created, **kwargs):
     if not created:
         return
-    Notification.objects.create(
-        user=instance.following,
-        from_user=instance.follower,
-        notification_type="follow",
-    )
     channel_layer = get_channel_layer()
     data = {
         'type': 'notify',


### PR DESCRIPTION
## Summary
- remove duplicate notification entry in follow signal
- document backend and frontend test commands

## Testing
- `python manage.py test` *(fails: ImportError: No module named 'django')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688735e16d2083248198cdab5537c758