### PR TITLE
Add loading skeletons to sidebar components

### DIFF
--- a/frontend/src/components/MyActivity.jsx
+++ b/frontend/src/components/MyActivity.jsx
@@ -3,24 +3,35 @@ import API from "../api";
 
 const MyActivity = () => {
   const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     API.get("/profile/stats/")
       .then((res) => setStats(res.data))
-      .catch((err) => console.error(err));
+      .catch((err) => console.error(err))
+      .finally(() => setLoading(false));
   }, []);
 
   return (
     <div className="mb-6">
       <h2 className="font-semibold mb-2">My Activity</h2>
       <ul className="space-y-1">
-        {stats && (
-          <>
-            <li className="text-sm">Posts: {stats.post_count}</li>
-            <li className="text-sm">Following: {stats.following_count}</li>
-            <li className="text-sm">Followers: {stats.follower_count}</li>
-            <li className="text-sm">Saved Posts: {stats.bookmark_count}</li>
-          </>
+        {loading ? (
+          Array.from({ length: 4 }).map((_, idx) => (
+            <li
+              key={idx}
+              className="h-4 bg-gray-300 rounded animate-pulse"
+            ></li>
+          ))
+        ) : (
+          stats && (
+            <>
+              <li className="text-sm">Posts: {stats.post_count}</li>
+              <li className="text-sm">Following: {stats.following_count}</li>
+              <li className="text-sm">Followers: {stats.follower_count}</li>
+              <li className="text-sm">Saved Posts: {stats.bookmark_count}</li>
+            </>
+          )
         )}
       </ul>
     </div>

--- a/frontend/src/components/NotificationsPanel.jsx
+++ b/frontend/src/components/NotificationsPanel.jsx
@@ -3,6 +3,7 @@ import API from "../api";
 
 const NotificationsPanel = () => {
   const [notes, setNotes] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     API.get("/notifications/?unread_first=true")
@@ -16,7 +17,8 @@ const NotificationsPanel = () => {
           }
         });
       })
-      .catch((err) => console.error(err));
+      .catch((err) => console.error(err))
+      .finally(() => setLoading(false));
   }, []);
 
   const renderMessage = (n) => {
@@ -42,25 +44,32 @@ const NotificationsPanel = () => {
     <div className="mb-6">
       <h2 className="font-semibold mb-2">Notifications</h2>
       <ul className="space-y-1">
-        {notes.map((n, idx) => (
-          <li
-            key={n.id || idx}
-            className={`text-sm ${n.is_read ? '' : 'font-semibold'}`}
-            onClick={() => {
-              if (!n.is_read) {
-                API.patch(`/notifications/${n.id}/`, { is_read: true })
-                  .then(() => {
-                    setNotes((prev) =>
-                      prev.map((p) => (p.id === n.id ? { ...p, is_read: true } : p))
-                    );
-                  })
-                  .catch((err) => console.error(err));
-              }
-            }}
-          >
-            {renderMessage(n)}
-          </li>
-        ))}
+        {loading
+          ? Array.from({ length: 3 }).map((_, idx) => (
+              <li
+                key={idx}
+                className="h-4 bg-gray-300 rounded animate-pulse"
+              ></li>
+            ))
+          : notes.map((n, idx) => (
+              <li
+                key={n.id || idx}
+                className={`text-sm ${n.is_read ? '' : 'font-semibold'}`}
+                onClick={() => {
+                  if (!n.is_read) {
+                    API.patch(`/notifications/${n.id}/`, { is_read: true })
+                      .then(() => {
+                        setNotes((prev) =>
+                          prev.map((p) => (p.id === n.id ? { ...p, is_read: true } : p))
+                        );
+                      })
+                      .catch((err) => console.error(err));
+                  }
+                }}
+              >
+                {renderMessage(n)}
+              </li>
+            ))}
       </ul>
     </div>
   );

--- a/frontend/src/components/SavedPosts.jsx
+++ b/frontend/src/components/SavedPosts.jsx
@@ -4,11 +4,13 @@ import API from "../api";
 
 const SavedPosts = () => {
   const [bookmarks, setBookmarks] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     API.get("/bookmarks/")
       .then((res) => setBookmarks(res.data.results || res.data))
-      .catch((err) => console.error(err));
+      .catch((err) => console.error(err))
+      .finally(() => setLoading(false));
   }, []);
 
   const remove = (id) => {
@@ -21,22 +23,29 @@ const SavedPosts = () => {
     <div className="mb-6">
       <h2 className="font-semibold mb-2">Saved Posts</h2>
       <ul className="space-y-1">
-        {bookmarks.map((b) => (
-          <li key={b.id} className="flex items-center justify-between">
-            <Link
-              to={`/posts/${b.post.id}`}
-              className="text-sm text-blue-600 hover:underline"
-            >
-              {b.post.caption}
-            </Link>
-            <button
-              onClick={() => remove(b.id)}
-              className="text-xs text-red-500 ml-2"
-            >
-              Remove
-            </button>
-          </li>
-        ))}
+        {loading
+          ? Array.from({ length: 3 }).map((_, idx) => (
+              <li
+                key={idx}
+                className="h-4 bg-gray-300 rounded animate-pulse"
+              ></li>
+            ))
+          : bookmarks.map((b) => (
+              <li key={b.id} className="flex items-center justify-between">
+                <Link
+                  to={`/posts/${b.post.id}`}
+                  className="text-sm text-blue-600 hover:underline"
+                >
+                  {b.post.caption}
+                </Link>
+                <button
+                  onClick={() => remove(b.id)}
+                  className="text-xs text-red-500 ml-2"
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
       </ul>
     </div>
   );

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -4,27 +4,36 @@ import API from "../api";
 
 const SuggestedUsers = () => {
   const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     API.get("/users/suggested/")
       .then((res) => setUsers(res.data.results || res.data))
-      .catch((err) => console.error(err));
+      .catch((err) => console.error(err))
+      .finally(() => setLoading(false));
   }, []);
 
   return (
     <div className="mb-6">
       <h2 className="font-semibold mb-2">Suggested Users</h2>
       <ul className="space-y-1">
-        {users.map((user) => (
-          <li key={user.id || user.username}>
-            <Link
-              to={`/user/${user.username}`}
-              className="text-sm text-blue-600 hover:underline"
-            >
-              @{user.username}
-            </Link>
-          </li>
-        ))}
+        {loading
+          ? Array.from({ length: 3 }).map((_, idx) => (
+              <li
+                key={idx}
+                className="h-4 bg-gray-300 rounded animate-pulse"
+              ></li>
+            ))
+          : users.map((user) => (
+              <li key={user.id || user.username}>
+                <Link
+                  to={`/user/${user.username}`}
+                  className="text-sm text-blue-600 hover:underline"
+                >
+                  @{user.username}
+                </Link>
+              </li>
+            ))}
       </ul>
     </div>
   );

--- a/frontend/src/components/TagList.jsx
+++ b/frontend/src/components/TagList.jsx
@@ -4,26 +4,35 @@ import { Link } from "react-router-dom";
 
 const TagList = () => {
   const [tags, setTags] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     API.get("/tags/")
       .then((res) => setTags(res.data.results || res.data))
-      .catch((err) => console.error(err));
+      .catch((err) => console.error(err))
+      .finally(() => setLoading(false));
   }, []);
 
   return (
     <div className="mb-6">
       <h2 className="font-semibold mb-2">Trending Tags</h2>
       <div className="flex flex-wrap gap-2">
-        {tags.map((tag) => (
-          <Link
-            key={tag.id || tag}
-            to={`/tag/${tag.name || tag}`}
-            className="text-xs px-2 py-1 bg-gray-200 rounded"
-          >
-            #{tag.name || tag}
-          </Link>
-        ))}
+        {loading
+          ? Array.from({ length: 5 }).map((_, idx) => (
+              <div
+                key={idx}
+                className="h-5 w-16 bg-gray-300 rounded animate-pulse"
+              ></div>
+            ))
+          : tags.map((tag) => (
+              <Link
+                key={tag.id || tag}
+                to={`/tag/${tag.name || tag}`}
+                className="text-xs px-2 py-1 bg-gray-200 rounded"
+              >
+                #{tag.name || tag}
+              </Link>
+            ))}
       </div>
     </div>
   );

--- a/frontend/src/components/TrendingPosts.jsx
+++ b/frontend/src/components/TrendingPosts.jsx
@@ -4,27 +4,36 @@ import API from "../api";
 
 const TrendingPosts = () => {
   const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     API.get("/posts/trending/")
       .then((res) => setPosts(res.data.results || res.data))
-      .catch((err) => console.error(err));
+      .catch((err) => console.error(err))
+      .finally(() => setLoading(false));
   }, []);
 
   return (
     <div className="mb-6">
       <h2 className="font-semibold mb-2">Trending Posts</h2>
       <ul className="space-y-1">
-        {posts.map((p) => (
-          <li key={p.id}>
-            <Link
-              to={`/posts/${p.id}`}
-              className="text-sm text-blue-600 hover:underline"
-            >
-              {p.caption}
-            </Link>
-          </li>
-        ))}
+        {loading
+          ? Array.from({ length: 3 }).map((_, idx) => (
+              <li
+                key={idx}
+                className="h-4 bg-gray-300 rounded animate-pulse"
+              ></li>
+            ))
+          : posts.map((p) => (
+              <li key={p.id}>
+                <Link
+                  to={`/posts/${p.id}`}
+                  className="text-sm text-blue-600 hover:underline"
+                >
+                  {p.caption}
+                </Link>
+              </li>
+            ))}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- add loading state to sidebar widgets
- show Tailwind pulse placeholders while data is loading

## Testing
- `npm test --prefix frontend --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876e17d8688324a2f262b813f551d8