### PR TITLE
Add dark mode styles to sidebars

### DIFF
--- a/frontend/src/components/LeftSidebar.jsx
+++ b/frontend/src/components/LeftSidebar.jsx
@@ -5,7 +5,7 @@ import SuggestedUsers from "./SuggestedUsers";
 
 const LeftSidebar = ({ mobileOpen, setMobileOpen }) => {
   const content = (
-    <div className="p-4 space-y-6">
+    <div className="p-4 space-y-6 text-gray-700 dark:text-gray-200">
       <TrendingPosts />
       <TagList />
       <SuggestedUsers />
@@ -14,11 +14,11 @@ const LeftSidebar = ({ mobileOpen, setMobileOpen }) => {
 
   return (
     <>
-      <aside className="hidden lg:block w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto">
+      <aside className="hidden lg:block w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto text-gray-700 dark:text-gray-200">
         {content}
       </aside>
       {mobileOpen && (
-        <div className="lg:hidden fixed inset-0 bg-white z-50 overflow-y-auto">
+        <div className="lg:hidden fixed inset-0 bg-white dark:bg-gray-900 z-50 overflow-y-auto text-gray-700 dark:text-gray-200">
           <button
             onClick={() => setMobileOpen(false)}
             className="p-2 text-right block ml-auto mr-2 mt-2"

--- a/frontend/src/components/MyActivity.jsx
+++ b/frontend/src/components/MyActivity.jsx
@@ -11,7 +11,7 @@ const MyActivity = () => {
   }, []);
 
   return (
-    <div className="mb-6">
+    <div className="mb-6 p-4 bg-white rounded shadow text-gray-700 dark:bg-gray-900 dark:text-gray-200">
       <h2 className="font-semibold mb-2">My Activity</h2>
       <ul className="space-y-1">
         {stats && (

--- a/frontend/src/components/NotificationsPanel.jsx
+++ b/frontend/src/components/NotificationsPanel.jsx
@@ -39,7 +39,7 @@ const NotificationsPanel = () => {
   };
 
   return (
-    <div className="mb-6">
+    <div className="mb-6 p-4 bg-white rounded shadow text-gray-700 dark:bg-gray-900 dark:text-gray-200">
       <h2 className="font-semibold mb-2">Notifications</h2>
       <ul className="space-y-1">
         {notes.map((n, idx) => (

--- a/frontend/src/components/RightSidebar.jsx
+++ b/frontend/src/components/RightSidebar.jsx
@@ -5,7 +5,7 @@ import NotificationsPanel from "./NotificationsPanel";
 
 const RightSidebar = ({ mobileOpen, setMobileOpen }) => {
   const content = (
-    <div className="p-4 space-y-6">
+    <div className="p-4 space-y-6 text-gray-700 dark:text-gray-200">
       <MyActivity />
       <SavedPosts />
       <NotificationsPanel />
@@ -14,11 +14,11 @@ const RightSidebar = ({ mobileOpen, setMobileOpen }) => {
 
   return (
     <>
-      <aside className="hidden lg:block w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto">
+      <aside className="hidden lg:block w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto text-gray-700 dark:text-gray-200">
         {content}
       </aside>
       {mobileOpen && (
-        <div className="lg:hidden fixed inset-0 bg-white z-50 overflow-y-auto">
+        <div className="lg:hidden fixed inset-0 bg-white dark:bg-gray-900 z-50 overflow-y-auto text-gray-700 dark:text-gray-200">
           <button
             onClick={() => setMobileOpen(false)}
             className="p-2 text-right block ml-auto mr-2 mt-2"

--- a/frontend/src/components/SavedPosts.jsx
+++ b/frontend/src/components/SavedPosts.jsx
@@ -18,7 +18,7 @@ const SavedPosts = () => {
   };
 
   return (
-    <div className="mb-6">
+    <div className="mb-6 p-4 bg-white rounded shadow text-gray-700 dark:bg-gray-900 dark:text-gray-200">
       <h2 className="font-semibold mb-2">Saved Posts</h2>
       <ul className="space-y-1">
         {bookmarks.map((b) => (

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -12,7 +12,7 @@ const SuggestedUsers = () => {
   }, []);
 
   return (
-    <div className="mb-6">
+    <div className="mb-6 p-4 bg-white rounded shadow text-gray-700 dark:bg-gray-900 dark:text-gray-200">
       <h2 className="font-semibold mb-2">Suggested Users</h2>
       <ul className="space-y-1">
         {users.map((user) => (

--- a/frontend/src/components/TagList.jsx
+++ b/frontend/src/components/TagList.jsx
@@ -12,7 +12,7 @@ const TagList = () => {
   }, []);
 
   return (
-    <div className="mb-6">
+    <div className="mb-6 p-4 bg-white rounded shadow text-gray-700 dark:bg-gray-900 dark:text-gray-200">
       <h2 className="font-semibold mb-2">Trending Tags</h2>
       <div className="flex flex-wrap gap-2">
         {tags.map((tag) => (

--- a/frontend/src/components/TrendingPosts.jsx
+++ b/frontend/src/components/TrendingPosts.jsx
@@ -12,7 +12,7 @@ const TrendingPosts = () => {
   }, []);
 
   return (
-    <div className="mb-6">
+    <div className="mb-6 p-4 bg-white rounded shadow text-gray-700 dark:bg-gray-900 dark:text-gray-200">
       <h2 className="font-semibold mb-2">Trending Posts</h2>
       <ul className="space-y-1">
         {posts.map((p) => (


### PR DESCRIPTION
## Summary
- style left and right sidebars for dark mode
- apply dark background/text for sidebar section cards

## Testing
- `npm test` *(fails: jest not found)*
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68876e1b870883248d2bac6350ec6cf6