### PR TITLE
Move sidebar toggles to navbar

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -4,6 +4,9 @@ export default {
     "^.+\\.(js|jsx)$": "babel-jest"
   },
   moduleFileExtensions: ['js', 'jsx'],
+  moduleNameMapper: {
+    '^@heroicons/react/24/outline$': '<rootDir>/src/__mocks__/heroicons.js'
+  },
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.js'],
   collectCoverage: true,
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,8 @@
     "react-router-dom": "^7.6.1",
     "react-toastify": "^11.0.5",
     "redux": "^5.0.1",
-    "redux-thunk": "^3.1.0"
+    "redux-thunk": "^3.1.0",
+    "@heroicons/react": "^2.1.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx-source": "^7.27.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,26 +21,12 @@ function App() {
   const [showLeft, setShowLeft] = useState(false);
   const [showRight, setShowRight] = useState(false);
 
+  const toggleLeft = () => setShowLeft((v) => !v);
+  const toggleRight = () => setShowRight((v) => !v);
+
   return (
     <>
-      <Navbar />
-      {/* Mobile drawer toggles */}
-      <div className="lg:hidden fixed bottom-4 left-4 z-50">
-        <button
-          onClick={() => setShowLeft(true)}
-          className="bg-indigo-600 text-white px-3 py-2 rounded"
-        >
-          Menu
-        </button>
-      </div>
-      <div className="lg:hidden fixed bottom-4 right-4 z-50">
-        <button
-          onClick={() => setShowRight(true)}
-          className="bg-indigo-600 text-white px-3 py-2 rounded"
-        >
-          Menu
-        </button>
-      </div>
+      <Navbar onToggleLeft={toggleLeft} onToggleRight={toggleRight} />
       <div className="flex">
         <LeftSidebar mobileOpen={showLeft} setMobileOpen={setShowLeft} />
         <main className="flex-1 p-4">

--- a/frontend/src/__mocks__/heroicons.js
+++ b/frontend/src/__mocks__/heroicons.js
@@ -1,0 +1,4 @@
+import React from 'react';
+export const Bars3Icon = () => <svg />;
+export const BellIcon = () => <svg />;
+export default {};

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,10 +1,11 @@
 import { Link, useNavigate } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
+import { Bars3Icon, BellIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
 import { toast } from 'react-toastify';
 import { API_BASE_URL, WS_BASE_URL } from '../config';
 
-function Navbar() {
+function Navbar({ onToggleLeft, onToggleRight }) {
   const navigate = useNavigate();
   const token = localStorage.getItem('access');
   const [user, setUser] = useState(null);
@@ -45,8 +46,24 @@ function Navbar() {
 
   return (
     <nav className="bg-white shadow-md px-6 py-4 flex justify-between items-center">
-      <Link to="/" className="text-xl font-bold text-indigo-600">RedditGram</Link>
-      <div className="space-x-4">
+      <div className="flex items-center space-x-2">
+        <button
+          onClick={onToggleLeft}
+          className="lg:hidden text-gray-700"
+          aria-label="Toggle left sidebar"
+        >
+          <Bars3Icon className="w-6 h-6" />
+        </button>
+        <Link to="/" className="text-xl font-bold text-indigo-600">RedditGram</Link>
+      </div>
+      <div className="flex items-center space-x-4">
+        <button
+          onClick={onToggleRight}
+          className="lg:hidden text-gray-700"
+          aria-label="Toggle right sidebar"
+        >
+          <BellIcon className="w-6 h-6" />
+        </button>
         {token && user ? (
           <>
             <Link to="/feed" className="text-gray-700 hover:text-indigo-600">Feed</Link>


### PR DESCRIPTION
## Summary
- drop floating sidebar menu buttons
- add mobile buttons in the navbar using Heroicons
- expose toggle handlers from `App` to `Navbar`
- mock Heroicons for tests

## Testing
- `npm test` *(fails: jest not found)*
- `python manage.py test` *(fails: Django missing)*

------
https://chatgpt.com/codex/tasks/task_e_68876e1d63b88324bd38c756aafce362