### PR TITLE
Add collapsible sidebar sections

### DIFF
--- a/frontend/src/components/CollapsibleSection.jsx
+++ b/frontend/src/components/CollapsibleSection.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+
+const CollapsibleSection = ({ header, uniqueKey, children }) => {
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(uniqueKey);
+    if (stored === "false") {
+      setOpen(false);
+    }
+  }, [uniqueKey]);
+
+  const toggle = () => {
+    const newState = !open;
+    setOpen(newState);
+    localStorage.setItem(uniqueKey, newState);
+  };
+
+  return (
+    <div className="mb-6">
+      <button
+        onClick={toggle}
+        className="flex items-center justify-between w-full font-semibold mb-2"
+      >
+        <span>{header}</span>
+        <span>{open ? "\u25BC" : "\u25B6"}</span>
+      </button>
+      <div className={open ? "" : "hidden"}>{children}</div>
+    </div>
+  );
+};
+
+CollapsibleSection.propTypes = {
+  header: PropTypes.node.isRequired,
+  uniqueKey: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default CollapsibleSection;

--- a/frontend/src/components/MyActivity.jsx
+++ b/frontend/src/components/MyActivity.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import API from "../api";
+import CollapsibleSection from "./CollapsibleSection";
 
 const MyActivity = () => {
   const [stats, setStats] = useState(null);
@@ -11,8 +12,7 @@ const MyActivity = () => {
   }, []);
 
   return (
-    <div className="mb-6">
-      <h2 className="font-semibold mb-2">My Activity</h2>
+    <CollapsibleSection header="My Activity" uniqueKey="my-activity">
       <ul className="space-y-1">
         {stats && (
           <>
@@ -23,7 +23,7 @@ const MyActivity = () => {
           </>
         )}
       </ul>
-    </div>
+    </CollapsibleSection>
   );
 };
 

--- a/frontend/src/components/NotificationsPanel.jsx
+++ b/frontend/src/components/NotificationsPanel.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import API from "../api";
+import CollapsibleSection from "./CollapsibleSection";
 
 const NotificationsPanel = () => {
   const [notes, setNotes] = useState([]);
@@ -39,8 +40,7 @@ const NotificationsPanel = () => {
   };
 
   return (
-    <div className="mb-6">
-      <h2 className="font-semibold mb-2">Notifications</h2>
+    <CollapsibleSection header="Notifications" uniqueKey="notifications">
       <ul className="space-y-1">
         {notes.map((n, idx) => (
           <li
@@ -62,7 +62,7 @@ const NotificationsPanel = () => {
           </li>
         ))}
       </ul>
-    </div>
+    </CollapsibleSection>
   );
 };
 

--- a/frontend/src/components/SavedPosts.jsx
+++ b/frontend/src/components/SavedPosts.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import API from "../api";
+import CollapsibleSection from "./CollapsibleSection";
 
 const SavedPosts = () => {
   const [bookmarks, setBookmarks] = useState([]);
@@ -18,8 +19,7 @@ const SavedPosts = () => {
   };
 
   return (
-    <div className="mb-6">
-      <h2 className="font-semibold mb-2">Saved Posts</h2>
+    <CollapsibleSection header="Saved Posts" uniqueKey="saved-posts">
       <ul className="space-y-1">
         {bookmarks.map((b) => (
           <li key={b.id} className="flex items-center justify-between">
@@ -38,7 +38,7 @@ const SavedPosts = () => {
           </li>
         ))}
       </ul>
-    </div>
+    </CollapsibleSection>
   );
 };
 

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import API from "../api";
+import CollapsibleSection from "./CollapsibleSection";
 
 const SuggestedUsers = () => {
   const [users, setUsers] = useState([]);
@@ -12,8 +13,7 @@ const SuggestedUsers = () => {
   }, []);
 
   return (
-    <div className="mb-6">
-      <h2 className="font-semibold mb-2">Suggested Users</h2>
+    <CollapsibleSection header="Suggested Users" uniqueKey="suggested-users">
       <ul className="space-y-1">
         {users.map((user) => (
           <li key={user.id || user.username}>
@@ -26,7 +26,7 @@ const SuggestedUsers = () => {
           </li>
         ))}
       </ul>
-    </div>
+    </CollapsibleSection>
   );
 };
 

--- a/frontend/src/components/TagList.jsx
+++ b/frontend/src/components/TagList.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import API from "../api";
 import { Link } from "react-router-dom";
+import CollapsibleSection from "./CollapsibleSection";
 
 const TagList = () => {
   const [tags, setTags] = useState([]);
@@ -12,8 +13,7 @@ const TagList = () => {
   }, []);
 
   return (
-    <div className="mb-6">
-      <h2 className="font-semibold mb-2">Trending Tags</h2>
+    <CollapsibleSection header="Trending Tags" uniqueKey="trending-tags">
       <div className="flex flex-wrap gap-2">
         {tags.map((tag) => (
           <Link
@@ -25,7 +25,7 @@ const TagList = () => {
           </Link>
         ))}
       </div>
-    </div>
+    </CollapsibleSection>
   );
 };
 

--- a/frontend/src/components/TrendingPosts.jsx
+++ b/frontend/src/components/TrendingPosts.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import API from "../api";
+import CollapsibleSection from "./CollapsibleSection";
 
 const TrendingPosts = () => {
   const [posts, setPosts] = useState([]);
@@ -12,8 +13,7 @@ const TrendingPosts = () => {
   }, []);
 
   return (
-    <div className="mb-6">
-      <h2 className="font-semibold mb-2">Trending Posts</h2>
+    <CollapsibleSection header="Trending Posts" uniqueKey="trending-posts">
       <ul className="space-y-1">
         {posts.map((p) => (
           <li key={p.id}>
@@ -26,7 +26,7 @@ const TrendingPosts = () => {
           </li>
         ))}
       </ul>
-    </div>
+    </CollapsibleSection>
   );
 };
 


### PR DESCRIPTION
## Summary
- create reusable `CollapsibleSection` component
- persist collapsed state to `localStorage`
- wrap all sidebar sections with `CollapsibleSection`

## Testing
- `npm test --silent` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876e20558083248b6d73b5f43cb8bf