### PR TITLE
Enhance sidebar sections with icons and styling

### DIFF
--- a/frontend/src/__mocks__/heroicons.js
+++ b/frontend/src/__mocks__/heroicons.js
@@ -1,4 +1,9 @@
 import React from 'react';
 export const Bars3Icon = () => <svg />;
 export const BellIcon = () => <svg />;
+export const FireIcon = () => <svg />;
+export const TagIcon = () => <svg />;
+export const UserGroupIcon = () => <svg />;
+export const ChartBarIcon = () => <svg />;
+export const BookmarkIcon = () => <svg />;
 export default {};

--- a/frontend/src/components/MyActivity.jsx
+++ b/frontend/src/components/MyActivity.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import API from "../api";
+import { ChartBarIcon } from "@heroicons/react/24/outline";
 import CollapsibleSection from "./CollapsibleSection";
 
 const MyActivity = () => {
@@ -14,8 +15,16 @@ const MyActivity = () => {
   }, []);
 
   return (
-    <CollapsibleSection header="My Activity" uniqueKey="my-activity">
-      <ul className="space-y-1">
+    <CollapsibleSection
+      header={(
+        <>
+          <ChartBarIcon className="w-4 h-4 mr-1 inline" /> My Activity
+        </>
+      )}
+      uniqueKey="my-activity"
+    >
+      <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
+        <ul className="space-y-1">
         {loading ? (
           Array.from({ length: 4 }).map((_, idx) => (
             <li
@@ -33,7 +42,8 @@ const MyActivity = () => {
             </>
           )
         )}
-      </ul>
+        </ul>
+      </div>
     </CollapsibleSection>
   );
 };

--- a/frontend/src/components/NotificationsPanel.jsx
+++ b/frontend/src/components/NotificationsPanel.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { BellIcon } from "@heroicons/react/24/outline";
 import API from "../api";
 import CollapsibleSection from "./CollapsibleSection";
 
@@ -42,8 +43,16 @@ const NotificationsPanel = () => {
   };
 
   return (
-    <CollapsibleSection header="Notifications" uniqueKey="notifications">
-      <ul className="space-y-1">
+    <CollapsibleSection
+      header={(
+        <>
+          <BellIcon className="w-4 h-4 mr-1 inline" /> Notifications
+        </>
+      )}
+      uniqueKey="notifications"
+    >
+      <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
+        <ul className="space-y-1">
         {loading
           ? Array.from({ length: 3 }).map((_, idx) => (
               <li
@@ -70,7 +79,8 @@ const NotificationsPanel = () => {
                 {renderMessage(n)}
               </li>
             ))}
-      </ul>
+        </ul>
+      </div>
     </CollapsibleSection>
   );
 };

--- a/frontend/src/components/SavedPosts.jsx
+++ b/frontend/src/components/SavedPosts.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { BookmarkIcon } from "@heroicons/react/24/outline";
 import API from "../api";
 import CollapsibleSection from "./CollapsibleSection";
 
@@ -21,8 +22,16 @@ const SavedPosts = () => {
   };
 
   return (
-    <CollapsibleSection header="Saved Posts" uniqueKey="saved-posts">
-      <ul className="space-y-1">
+    <CollapsibleSection
+      header={(
+        <>
+          <BookmarkIcon className="w-4 h-4 mr-1 inline" /> Saved Posts
+        </>
+      )}
+      uniqueKey="saved-posts"
+    >
+      <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
+        <ul className="space-y-1">
         {loading
           ? Array.from({ length: 3 }).map((_, idx) => (
               <li
@@ -46,7 +55,8 @@ const SavedPosts = () => {
                 </button>
               </li>
             ))}
-      </ul>
+        </ul>
+      </div>
     </CollapsibleSection>
   );
 };

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { UserGroupIcon } from "@heroicons/react/24/outline";
 import API from "../api";
 import CollapsibleSection from "./CollapsibleSection";
 
@@ -15,8 +16,16 @@ const SuggestedUsers = () => {
   }, []);
 
   return (
-    <CollapsibleSection header="Suggested Users" uniqueKey="suggested-users">
-      <ul className="space-y-1">
+    <CollapsibleSection
+      header={(
+        <>
+          <UserGroupIcon className="w-4 h-4 mr-1 inline" /> Suggested Users
+        </>
+      )}
+      uniqueKey="suggested-users"
+    >
+      <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
+        <ul className="space-y-1">
         {loading
           ? Array.from({ length: 3 }).map((_, idx) => (
               <li
@@ -34,7 +43,8 @@ const SuggestedUsers = () => {
                 </Link>
               </li>
             ))}
-      </ul>
+        </ul>
+      </div>
     </CollapsibleSection>
   );
 };

--- a/frontend/src/components/TagList.jsx
+++ b/frontend/src/components/TagList.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import API from "../api";
 import { Link } from "react-router-dom";
+import { TagIcon } from "@heroicons/react/24/outline";
 import CollapsibleSection from "./CollapsibleSection";
 
 const TagList = () => {
@@ -15,8 +16,16 @@ const TagList = () => {
   }, []);
 
   return (
-    <CollapsibleSection header="Trending Tags" uniqueKey="trending-tags">
-      <div className="flex flex-wrap gap-2">
+    <CollapsibleSection
+      header={(
+        <>
+          <TagIcon className="w-4 h-4 mr-1 inline" /> Trending Tags
+        </>
+      )}
+      uniqueKey="trending-tags"
+    >
+      <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
+        <div className="flex flex-wrap gap-2">
         {loading
           ? Array.from({ length: 5 }).map((_, idx) => (
               <div
@@ -33,6 +42,7 @@ const TagList = () => {
                 #{tag.name || tag}
               </Link>
             ))}
+        </div>
       </div>
     </CollapsibleSection>
   );

--- a/frontend/src/components/TrendingPosts.jsx
+++ b/frontend/src/components/TrendingPosts.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { FireIcon } from "@heroicons/react/24/outline";
 import API from "../api";
 import CollapsibleSection from "./CollapsibleSection";
 
@@ -15,8 +16,16 @@ const TrendingPosts = () => {
   }, []);
 
   return (
-    <CollapsibleSection header="Trending Posts" uniqueKey="trending-posts">
-      <ul className="space-y-1">
+    <CollapsibleSection
+      header={(
+        <>
+          <FireIcon className="w-4 h-4 mr-1 inline" /> Trending Posts
+        </>
+      )}
+      uniqueKey="trending-posts"
+    >
+      <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
+        <ul className="space-y-1">
         {loading
           ? Array.from({ length: 3 }).map((_, idx) => (
               <li
@@ -34,7 +43,8 @@ const TrendingPosts = () => {
                 </Link>
               </li>
             ))}
-      </ul>
+        </ul>
+      </div>
     </CollapsibleSection>
   );
 };


### PR DESCRIPTION
## Summary
- wrap sidebar section content in styled containers
- show header icons for Trending Posts, Tags, Suggested Users, My Activity, Saved Posts and Notifications
- extend heroicons test mock for added icons

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887aa00eaec8324ae18e25173db3b10