### PR TITLE
Add dark mode support for sidebar components

### DIFF
--- a/frontend/src/components/CollapsibleSection.jsx
+++ b/frontend/src/components/CollapsibleSection.jsx
@@ -21,7 +21,7 @@ const CollapsibleSection = ({ header, uniqueKey, children }) => {
     <div className="mb-6">
       <button
         onClick={toggle}
-        className="flex items-center justify-between w-full font-semibold mb-2"
+        className="flex items-center justify-between w-full font-semibold mb-2 text-gray-700 dark:text-gray-200"
       >
         <span>{header}</span>
         <span>{open ? "\u25BC" : "\u25B6"}</span>

--- a/frontend/src/components/LeftSidebar.jsx
+++ b/frontend/src/components/LeftSidebar.jsx
@@ -7,7 +7,7 @@ import { XMarkIcon } from "@heroicons/react/24/outline";
 
 const LeftSidebar = ({ mobileOpen, setMobileOpen }) => {
   const content = (
-    <div className="p-4 space-y-6">
+    <div className="p-4 space-y-6 text-gray-700 dark:text-gray-200">
       <TrendingPosts />
       <TagList />
       <SuggestedUsers />
@@ -16,7 +16,7 @@ const LeftSidebar = ({ mobileOpen, setMobileOpen }) => {
 
   return (
     <>
-      <aside className="hidden lg:block w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto">
+      <aside className="hidden lg:block w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto text-gray-700 dark:text-gray-200">
         {content}
       </aside>
       <AnimatePresence>
@@ -30,7 +30,7 @@ const LeftSidebar = ({ mobileOpen, setMobileOpen }) => {
               onClick={() => setMobileOpen(false)}
             />
             <motion.div
-              className="lg:hidden fixed inset-0 bg-white z-50 overflow-y-auto"
+              className="lg:hidden fixed inset-0 bg-white dark:bg-gray-900 z-50 overflow-y-auto text-gray-700 dark:text-gray-200"
               initial={{ x: "-100%", opacity: 0 }}
               animate={{ x: 0, opacity: 1 }}
               exit={{ x: "-100%", opacity: 0 }}

--- a/frontend/src/components/MyActivity.jsx
+++ b/frontend/src/components/MyActivity.jsx
@@ -24,12 +24,12 @@ const MyActivity = () => {
       uniqueKey="my-activity"
     >
       <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
-        <ul className="space-y-1">
+        <ul className="space-y-1 text-gray-700 dark:text-gray-200">
         {loading ? (
           Array.from({ length: 4 }).map((_, idx) => (
             <li
               key={idx}
-              className="h-4 bg-gray-300 rounded animate-pulse"
+              className="h-4 bg-gray-300 dark:bg-gray-700 rounded animate-pulse"
             ></li>
           ))
         ) : (

--- a/frontend/src/components/NotificationsPanel.jsx
+++ b/frontend/src/components/NotificationsPanel.jsx
@@ -52,18 +52,18 @@ const NotificationsPanel = () => {
       uniqueKey="notifications"
     >
       <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
-        <ul className="space-y-1">
+        <ul className="space-y-1 text-gray-700 dark:text-gray-200">
         {loading
           ? Array.from({ length: 3 }).map((_, idx) => (
               <li
                 key={idx}
-                className="h-4 bg-gray-300 rounded animate-pulse"
+                className="h-4 bg-gray-300 dark:bg-gray-700 rounded animate-pulse"
               ></li>
             ))
           : notes.map((n, idx) => (
               <li
                 key={n.id || idx}
-                className={`text-sm ${n.is_read ? '' : 'font-semibold'}`}
+                className={`text-sm ${n.is_read ? '' : 'font-semibold'} text-gray-700 dark:text-gray-200`}
                 onClick={() => {
                   if (!n.is_read) {
                     API.patch(`/notifications/${n.id}/`, { is_read: true })

--- a/frontend/src/components/RightSidebar.jsx
+++ b/frontend/src/components/RightSidebar.jsx
@@ -7,7 +7,7 @@ import { XMarkIcon } from "@heroicons/react/24/outline";
 
 const RightSidebar = ({ mobileOpen, setMobileOpen }) => {
   const content = (
-    <div className="p-4 space-y-6">
+    <div className="p-4 space-y-6 text-gray-700 dark:text-gray-200">
       <MyActivity />
       <SavedPosts />
       <NotificationsPanel />
@@ -16,7 +16,7 @@ const RightSidebar = ({ mobileOpen, setMobileOpen }) => {
 
   return (
     <>
-      <aside className="hidden lg:block w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto">
+      <aside className="hidden lg:block w-64 shrink-0 sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto text-gray-700 dark:text-gray-200">
         {content}
       </aside>
       <AnimatePresence>
@@ -30,7 +30,7 @@ const RightSidebar = ({ mobileOpen, setMobileOpen }) => {
               onClick={() => setMobileOpen(false)}
             />
             <motion.div
-              className="lg:hidden fixed inset-0 bg-white z-50 overflow-y-auto"
+              className="lg:hidden fixed inset-0 bg-white dark:bg-gray-900 z-50 overflow-y-auto text-gray-700 dark:text-gray-200"
               initial={{ x: "100%", opacity: 0 }}
               animate={{ x: 0, opacity: 1 }}
               exit={{ x: "100%", opacity: 0 }}

--- a/frontend/src/components/SavedPosts.jsx
+++ b/frontend/src/components/SavedPosts.jsx
@@ -31,19 +31,19 @@ const SavedPosts = () => {
       uniqueKey="saved-posts"
     >
       <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
-        <ul className="space-y-1">
+        <ul className="space-y-1 text-gray-700 dark:text-gray-200">
         {loading
           ? Array.from({ length: 3 }).map((_, idx) => (
               <li
                 key={idx}
-                className="h-4 bg-gray-300 rounded animate-pulse"
+                className="h-4 bg-gray-300 dark:bg-gray-700 rounded animate-pulse"
               ></li>
             ))
           : bookmarks.map((b) => (
               <li key={b.id} className="flex items-center justify-between">
                 <Link
                   to={`/posts/${b.post.id}`}
-                  className="text-sm text-blue-600 hover:underline"
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
                 >
                   {b.post.caption}
                 </Link>

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -25,19 +25,19 @@ const SuggestedUsers = () => {
       uniqueKey="suggested-users"
     >
       <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
-        <ul className="space-y-1">
+        <ul className="space-y-1 text-gray-700 dark:text-gray-200">
         {loading
           ? Array.from({ length: 3 }).map((_, idx) => (
               <li
                 key={idx}
-                className="h-4 bg-gray-300 rounded animate-pulse"
+                className="h-4 bg-gray-300 dark:bg-gray-700 rounded animate-pulse"
               ></li>
             ))
           : users.map((user) => (
               <li key={user.id || user.username}>
                 <Link
                   to={`/user/${user.username}`}
-                  className="text-sm text-blue-600 hover:underline"
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
                 >
                   @{user.username}
                 </Link>

--- a/frontend/src/components/TagList.jsx
+++ b/frontend/src/components/TagList.jsx
@@ -25,19 +25,19 @@ const TagList = () => {
       uniqueKey="trending-tags"
     >
       <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2 text-gray-700 dark:text-gray-200">
         {loading
           ? Array.from({ length: 5 }).map((_, idx) => (
               <div
                 key={idx}
-                className="h-5 w-16 bg-gray-300 rounded animate-pulse"
+                className="h-5 w-16 bg-gray-300 dark:bg-gray-700 rounded animate-pulse"
               ></div>
             ))
           : tags.map((tag) => (
               <Link
                 key={tag.id || tag}
                 to={`/tag/${tag.name || tag}`}
-                className="text-xs px-2 py-1 bg-gray-200 rounded"
+                className="text-xs px-2 py-1 bg-gray-200 dark:bg-gray-700 dark:text-gray-200 rounded"
               >
                 #{tag.name || tag}
               </Link>

--- a/frontend/src/components/TrendingPosts.jsx
+++ b/frontend/src/components/TrendingPosts.jsx
@@ -25,19 +25,19 @@ const TrendingPosts = () => {
       uniqueKey="trending-posts"
     >
       <div className="bg-gray-100 dark:bg-gray-800 p-3 rounded-lg">
-        <ul className="space-y-1">
+        <ul className="space-y-1 text-gray-700 dark:text-gray-200">
         {loading
           ? Array.from({ length: 3 }).map((_, idx) => (
               <li
                 key={idx}
-                className="h-4 bg-gray-300 rounded animate-pulse"
+                className="h-4 bg-gray-300 dark:bg-gray-700 rounded animate-pulse"
               ></li>
             ))
           : posts.map((p) => (
               <li key={p.id}>
                 <Link
                   to={`/posts/${p.id}`}
-                  className="text-sm text-blue-600 hover:underline"
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
                 >
                   {p.caption}
                 </Link>


### PR DESCRIPTION
## Summary
- apply consistent dark text styles to `CollapsibleSection` headers
- add dark styles to left and right sidebar containers and mobile panels
- update all sidebar sections with dark text and background variants

## Testing
- `npm test --silent` *(fails: jest not found)*
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6887ab8239f083249d12b545b6daac66