### PR TITLE
Add bookmark details in API

### DIFF
--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -11,6 +11,8 @@ class PostSerializer(serializers.ModelSerializer):
     comment_count = serializers.SerializerMethodField()
     like_count = serializers.SerializerMethodField()
     is_liked = serializers.SerializerMethodField()
+    is_bookmarked = serializers.SerializerMethodField()
+    bookmark_id = serializers.SerializerMethodField()
     author_avatar = serializers.SerializerMethodField()
     tags = TagSerializer(many=True, read_only=True)
     tag_names = serializers.ListField(
@@ -28,6 +30,8 @@ class PostSerializer(serializers.ModelSerializer):
             'comment_count',
             'like_count',
             'is_liked',
+            'is_bookmarked',
+            'bookmark_id',
             'tags',
             'tag_names',
         ]
@@ -44,6 +48,17 @@ class PostSerializer(serializers.ModelSerializer):
         if request and request.user.is_authenticated:
             return obj.likes.filter(user=request.user).exists()
         return False
+
+    def get_bookmark_id(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            bookmark = obj.bookmarks.filter(user=request.user).first()
+            if bookmark:
+                return bookmark.id
+        return None
+
+    def get_is_bookmarked(self, obj):
+        return self.get_bookmark_id(obj) is not None
 
     def get_author_avatar(self, obj):
         avatar = getattr(obj.author.profile, 'avatar', None)
@@ -89,6 +104,14 @@ class CommentSerializer(serializers.ModelSerializer):
 
 
 class BookmarkSerializer(serializers.ModelSerializer):
+    """Serialize bookmarks with nested post details for easy display."""
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        # Include basic post info so the frontend can link directly to the post
+        data["post"] = PostSerializer(instance.post, context=self.context).data
+        return data
+
     class Meta:
         model = Bookmark
         fields = ['id', 'user', 'post', 'created_at']

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -360,6 +360,13 @@ class BookmarkAPITestCase(TestCase):
         detail_url = reverse("bookmark-detail", args=[bookmark_id])
         resp = self.client.get(detail_url)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        # response should include serialized post data
+        self.assertEqual(resp.data["post"]["id"], self.post.id)
+        self.assertIn("caption", resp.data["post"])
+
+        list_resp = self.client.get(create_url)
+        self.assertEqual(list_resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(list_resp.data["results"][0]["post"]["id"], self.post.id)
 
         resp = self.client.delete(detail_url)
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import API from "../api";
 import { motion } from "framer-motion";
+import { BookmarkIcon as BookmarkIconOutline } from "@heroicons/react/24/outline";
+import { BookmarkIcon as BookmarkIconSolid } from "@heroicons/react/24/solid";
 import { formatDistanceToNow } from "date-fns";
 // Utility to generate background color from username and caption
 const getColorFromUsername = (username, caption = "") => {
@@ -91,6 +93,8 @@ export const PostCard = ({ post }) => {
 
   const [liked, setLiked] = useState(post.is_liked);
   const [likeCount, setLikeCount] = useState(post.like_count);
+  const [bookmarked, setBookmarked] = useState(post.is_bookmarked);
+  const [bookmarkId, setBookmarkId] = useState(post.bookmark_id);
   const [comments, setComments] = useState([]);
   const [showComments, setShowComments] = useState(false);
   const [newComment, setNewComment] = useState("");
@@ -109,6 +113,22 @@ export const PostCard = ({ post }) => {
       const res = await API.post(`/posts/${post.id}/like/`);
       setLiked(res.data.liked);
       setLikeCount(res.data.like_count);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const toggleBookmark = async () => {
+    try {
+      if (bookmarked) {
+        await API.delete(`/bookmarks/${bookmarkId}/`);
+        setBookmarked(false);
+        setBookmarkId(null);
+      } else {
+        const res = await API.post('/bookmarks/', { post: post.id });
+        setBookmarked(true);
+        setBookmarkId(res.data.id);
+      }
     } catch (err) {
       console.error(err);
     }
@@ -194,6 +214,13 @@ export const PostCard = ({ post }) => {
         </button>
         <button onClick={() => setShowComments(!showComments)} className="text-sm">
           💬 {post.comment_count}
+        </button>
+        <button onClick={toggleBookmark} className="text-sm">
+          {bookmarked ? (
+            <BookmarkIconSolid className="w-4 h-4 inline" />
+          ) : (
+            <BookmarkIconOutline className="w-4 h-4 inline" />
+          )}
         </button>
         <span className="ml-auto text-xs text-white/80">{timeAgo}</span>
       </div>


### PR DESCRIPTION
## Summary
- embed PostSerializer data inside BookmarkSerializer
- verify bookmark endpoints return nested post info in tests

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688842fba1e0832490df3e76df07b2c0