### PR TITLE
Add post detail view

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Home from './pages/Home';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 import CreatePost from './pages/CreatePost';
+import PostDetail from './pages/PostDetail';
 import UserPosts from './pages/UserPosts'; // ← NEW
 import FollowersList from './pages/FollowersList';
 import FollowingList from './pages/FollowingList';
@@ -35,6 +36,7 @@ function App() {
             <Route path="/login" element={<Login />} />
             <Route path="/signup" element={<Signup />} />
             <Route path="/create" element={<CreatePost />} />
+            <Route path="/posts/:id" element={<PostDetail />} />
             <Route path="/feed" element={<Feed />} />
             <Route path="/search" element={<Search />} />
             <Route path="/tag/:name" element={<TagPosts />} />

--- a/frontend/src/__tests__/postdetail.test.jsx
+++ b/frontend/src/__tests__/postdetail.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import PostDetail from '../pages/PostDetail';
+import API from '../api';
+
+jest.mock('../api');
+
+const samplePost = { id: 1, caption: 'sample', author_username: 'bob' };
+
+test('renders post detail and fetches data', async () => {
+  API.get.mockResolvedValue({ data: samplePost });
+
+  render(
+    <MemoryRouter initialEntries={["/posts/1"]}>
+      <Routes>
+        <Route path="/posts/:id" element={<PostDetail />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  await waitFor(() => {
+    expect(API.get).toHaveBeenCalledWith('/posts/1/');
+  });
+
+  expect(await screen.findByText(samplePost.caption)).toBeInTheDocument();
+});

--- a/frontend/src/pages/PostDetail.jsx
+++ b/frontend/src/pages/PostDetail.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import API from '../api';
+import { PostCard } from '../components/PostCard';
+
+const PostDetail = () => {
+  const { id } = useParams();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    API.get(`/posts/${id}/`)
+      .then((res) => {
+        setData(res.data);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('Failed to load post.');
+        setLoading(false);
+      });
+  }, [id]);
+
+  if (loading) {
+    return <div className="text-center mt-20 text-blue-600">Loading...</div>;
+  }
+
+  if (error) {
+    return <div className="text-center mt-20 text-red-600">{error}</div>;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {data && <PostCard post={data} />}
+    </div>
+  );
+};
+
+export default PostDetail;


### PR DESCRIPTION
## Summary
- show a single post via new `PostDetail` page
- add route `/posts/:id`
- test the component fetch call and render

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find ESLint packages)*

------
https://chatgpt.com/codex/tasks/task_e_688851a2dd948324aa26655e3fab1cc6