### PR TITLE
Add comment like feature

### DIFF
--- a/frontend/src/__tests__/commentlike.test.jsx
+++ b/frontend/src/__tests__/commentlike.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PostCard } from '../components/PostCard';
+import API, { likeComment } from '../api';
+
+jest.mock('../api', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+    put: jest.fn(),
+    interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } },
+  },
+  likeComment: jest.fn(),
+}));
+
+const samplePost = {
+  id: 1,
+  caption: 'sample',
+  author_username: 'bob',
+  is_liked: false,
+  like_count: 0,
+  is_bookmarked: false,
+  comment_count: 1,
+};
+
+const sampleComments = {
+  results: [
+    { id: 2, text: 'hey', author_username: 'alice', is_liked: false, like_count: 0 },
+  ],
+};
+
+test('liking a comment updates count', async () => {
+  API.get.mockResolvedValueOnce({ data: sampleComments });
+  likeComment.mockResolvedValue({ liked: true, like_count: 1 });
+
+  render(<PostCard post={samplePost} />);
+
+  fireEvent.click(screen.getByText(/💬/));
+
+  await screen.findByText('hey');
+
+  const btn = screen.getByText('🤍 0');
+  fireEvent.click(btn);
+
+  await waitFor(() => {
+    expect(likeComment).toHaveBeenCalledWith(2);
+  });
+
+  expect(await screen.findByText('💖 1')).toBeInTheDocument();
+});

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -57,4 +57,9 @@ API.interceptors.response.use(
   }
 );
 
+export const likeComment = async (commentId) => {
+  const res = await API.post(`/comments/${commentId}/like/`);
+  return res.data;
+};
+
 export default API;

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import API from "../api";
+import API, { likeComment } from "../api";
 import { motion } from "framer-motion";
 import { BookmarkIcon as BookmarkIconOutline } from "@heroicons/react/24/outline";
 import { BookmarkIcon as BookmarkIconSolid } from "@heroicons/react/24/solid";
@@ -174,6 +174,21 @@ export const PostCard = ({ post }) => {
     }
   };
 
+  const toggleCommentLike = async (id) => {
+    try {
+      const data = await likeComment(id);
+      setComments((prev) => {
+        const updated = { ...prev };
+        updated.results = updated.results.map((c) =>
+          c.id === id ? { ...c, is_liked: data.liked, like_count: data.like_count } : c
+        );
+        return updated;
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
 
   return (
     <motion.div
@@ -245,8 +260,11 @@ export const PostCard = ({ post }) => {
                   </button>
                 </>
               ) : (
-                <>
+                <> 
                   {' '}{c.text}
+                  <button onClick={() => toggleCommentLike(c.id)} className="ml-1 text-xs">
+                    {c.is_liked ? '💖' : '🤍'} {c.like_count ?? 0}
+                  </button>
                   {loggedInUsername === c.author_username && (
                     <>
                       <button onClick={() => startEdit(c)} className="ml-1 text-xs text-indigo-500">


### PR DESCRIPTION
## Summary
- implement `likeComment` helper to call `/comments/<id>/like/`
- support comment likes in `PostCard`
- test comment like behavior

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688863e15cd483249025ae1e43f63dd6