### PR TITLE
Add comment replies in frontend

### DIFF
--- a/frontend/src/__tests__/commentlike.test.jsx
+++ b/frontend/src/__tests__/commentlike.test.jsx
@@ -27,12 +27,13 @@ const samplePost = {
 
 const sampleComments = {
   results: [
-    { id: 2, text: 'hey', author_username: 'alice', is_liked: false, like_count: 0 },
+    { id: 2, text: 'hey', author_username: 'alice', is_liked: false, like_count: 0, replies: [] },
   ],
 };
 
 test('liking a comment updates count', async () => {
   API.get.mockResolvedValueOnce({ data: sampleComments });
+  API.get.mockResolvedValueOnce({ data: { results: [] } });
   likeComment.mockResolvedValue({ liked: true, like_count: 1 });
 
   render(<PostCard post={samplePost} />);
@@ -40,6 +41,7 @@ test('liking a comment updates count', async () => {
   fireEvent.click(screen.getByText(/💬/));
 
   await screen.findByText('hey');
+  expect(API.get).toHaveBeenCalledWith('/comments/2/replies/');
 
   const btn = screen.getByText('🤍 0');
   fireEvent.click(btn);

--- a/frontend/src/__tests__/replyflow.test.jsx
+++ b/frontend/src/__tests__/replyflow.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PostCard } from '../components/PostCard';
+import API from '../api';
+
+jest.mock('../api', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+    put: jest.fn(),
+    interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } },
+  },
+}));
+
+const samplePost = {
+  id: 1,
+  caption: 'sample',
+  author_username: 'bob',
+  is_liked: false,
+  like_count: 0,
+  is_bookmarked: false,
+  comment_count: 1,
+};
+
+const commentsFirst = { results: [ { id: 2, text: 'hey', author_username: 'alice', is_liked: false, like_count: 0 } ] };
+const repliesAfter = { results: [ { id: 3, text: 'reply', author_username: 'bob', is_liked: false, like_count: 0 } ] };
+
+test('user can reply to a comment', async () => {
+  API.get.mockResolvedValueOnce({ data: commentsFirst });
+  API.get.mockResolvedValueOnce({ data: { results: [] } });
+
+  render(<PostCard post={samplePost} />);
+
+  fireEvent.click(screen.getByText(/💬/));
+  await screen.findByText('hey');
+
+  fireEvent.click(screen.getByText('Reply'));
+  const input = screen.getByPlaceholderText('Add a reply');
+  fireEvent.change(input, { target: { value: 'reply' } });
+
+  API.post.mockResolvedValueOnce({});
+  API.get.mockResolvedValueOnce({ data: commentsFirst });
+  API.get.mockResolvedValueOnce({ data: repliesAfter });
+
+  fireEvent.click(screen.getByText(/^Post$/));
+
+  await waitFor(() => {
+    expect(API.post).toHaveBeenCalledWith('/comments/2/replies/', { text: 'reply' });
+  });
+
+  expect(await screen.findByText('reply')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- show replies in PostCard comments
- fetch replies from backend and allow adding new reply
- handle nested likes for replies
- add reply workflow tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68886a485c088324aca3dcb6c80b9f77