### PR TITLE
Support toggling replies

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -5,7 +5,9 @@ export default {
   },
   moduleFileExtensions: ['js', 'jsx'],
   moduleNameMapper: {
-    '^@heroicons/react/24/outline$': '<rootDir>/src/__mocks__/heroicons.js'
+    '^@heroicons/react/24/outline$': '<rootDir>/src/__mocks__/heroicons.js',
+    '^\.\./config$': '<rootDir>/src/__mocks__/config.js',
+    '^\.\/config$': '<rootDir>/src/__mocks__/config.js'
   },
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.js'],
   collectCoverage: true,

--- a/frontend/src/__mocks__/config.js
+++ b/frontend/src/__mocks__/config.js
@@ -1,0 +1,2 @@
+export const API_BASE_URL = 'http://localhost:9000/api';
+export const WS_BASE_URL = 'ws://localhost:9000';

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -102,7 +102,12 @@ export const PostCard = ({ post }) => {
   const [editText, setEditText] = useState("");
   const [replyingId, setReplyingId] = useState(null);
   const [replyText, setReplyText] = useState("");
+  const [openThreads, setOpenThreads] = useState({});
   const loggedInUsername = localStorage.getItem('username');
+
+  const toggleReplies = (id) => {
+    setOpenThreads((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
 
   const fetchComments = async () => {
     const res = await API.get(`/posts/${post.id}/comments/`);
@@ -113,6 +118,7 @@ export const PostCard = ({ post }) => {
       })
     );
     setComments({ ...res.data, results: commentsWithReplies });
+    setOpenThreads({});
   };
 
   useEffect(() => {
@@ -120,6 +126,10 @@ export const PostCard = ({ post }) => {
       fetchComments();
     }
   }, [showComments, post.id]);
+
+  useEffect(() => {
+    setOpenThreads({});
+  }, [post.id]);
 
   const toggleLike = async () => {
     try {
@@ -243,6 +253,9 @@ export const PostCard = ({ post }) => {
           <button onClick={() => { setReplyingId(c.id); setReplyText(''); }} className="ml-1 text-xs text-indigo-500">
             Reply
           </button>
+          <button onClick={() => toggleReplies(c.id)} className="ml-1 text-xs">
+            💬 {c.replies?.length ?? 0}
+          </button>
           {loggedInUsername === c.author_username && (
             <>
               <button onClick={() => startEdit(c)} className="ml-1 text-xs text-indigo-500">
@@ -268,7 +281,7 @@ export const PostCard = ({ post }) => {
           </button>
         </form>
       )}
-      {c.replies?.map?.((r) => renderComment(r, depth + 1))}
+      {openThreads[c.id] && c.replies?.map?.((r) => renderComment(r, depth + 1))}
     </div>
   );
 


### PR DESCRIPTION
## Summary
- add `openThreads` state to track which comments' replies are shown
- show a button to toggle replies for each comment
- only render replies when open
- reset open threads when loading comments or post changes
- map `config.js` in Jest and provide a stub for tests

## Testing
- `npm test --silent` *(fails: (0 , _dom.configure) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688c4d8658688324bf6d78a061cf37d3