### PR TITLE
Add cross-filter dropdowns for posts by profession and feeling

### DIFF
--- a/frontend/src/components/FeelingList.jsx
+++ b/frontend/src/components/FeelingList.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { FaceSmileIcon } from "@heroicons/react/24/outline";
 import CollapsibleSection from "./CollapsibleSection";
 
-const feelings = [
+export const feelings = [
   "happy",
   "sad",
   "angry",

--- a/frontend/src/pages/FeelingPosts.jsx
+++ b/frontend/src/pages/FeelingPosts.jsx
@@ -1,12 +1,40 @@
-import React from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import PostList from '../components/PostList';
+import { professions } from '../components/ProfessionList';
+
+const capitalize = (t) => t.charAt(0).toUpperCase() + t.slice(1);
 
 const FeelingPosts = () => {
   const { feeling } = useParams();
+  const navigate = useNavigate();
+  const [selectedProfession, setSelectedProfession] = useState('');
+
+  const handleChange = (e) => {
+    const val = e.target.value;
+    setSelectedProfession(val);
+    if (val) {
+      navigate(`/profession/${val}/${feeling}`);
+    } else {
+      navigate(`/feeling/${feeling}`);
+    }
+  };
+
   return (
     <div className="max-w-2xl mx-auto">
       <h2 className="text-xl font-semibold mb-4">Posts about {feeling}</h2>
+      <select
+        className="mb-4 p-2 border rounded"
+        value={selectedProfession}
+        onChange={handleChange}
+      >
+        <option value="">All Professions</option>
+        {professions.map((p) => (
+          <option key={p} value={p}>
+            {capitalize(p)}
+          </option>
+        ))}
+      </select>
       <PostList initialUrl={`/posts/feeling/${feeling}/`} />
     </div>
   );

--- a/frontend/src/pages/ProfessionPosts.jsx
+++ b/frontend/src/pages/ProfessionPosts.jsx
@@ -1,12 +1,40 @@
-import React from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import PostList from '../components/PostList';
+import { feelings } from '../components/FeelingList';
+
+const capitalize = (t) => t.charAt(0).toUpperCase() + t.slice(1);
 
 const ProfessionPosts = () => {
   const { profession } = useParams();
+  const navigate = useNavigate();
+  const [selectedFeeling, setSelectedFeeling] = useState('');
+
+  const handleChange = (e) => {
+    const val = e.target.value;
+    setSelectedFeeling(val);
+    if (val) {
+      navigate(`/profession/${profession}/${val}`);
+    } else {
+      navigate(`/profession/${profession}`);
+    }
+  };
+
   return (
     <div className="max-w-2xl mx-auto">
       <h2 className="text-xl font-semibold mb-4">Posts for {profession}</h2>
+      <select
+        className="mb-4 p-2 border rounded"
+        value={selectedFeeling}
+        onChange={handleChange}
+      >
+        <option value="">All Feelings</option>
+        {feelings.map((f) => (
+          <option key={f} value={f}>
+            {capitalize(f)}
+          </option>
+        ))}
+      </select>
       <PostList initialUrl={`/posts/profession/${profession}/`} />
     </div>
   );


### PR DESCRIPTION
## Summary
- export `feelings` array from `FeelingList`
- add a feelings filter to `ProfessionPosts` page
- add a professions filter to `FeelingPosts` page

## Testing
- `npm test` *(fails: TypeError (0 , _dom.configure) is not a function)*
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688c754a07608324ad7755a19533b895