### PR TITLE
Add edit icon for own posts and profile message link

### DIFF
--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import API, { likeComment } from "../api";
 import { motion } from "framer-motion";
-import { BookmarkIcon as BookmarkIconOutline } from "@heroicons/react/24/outline";
+import { BookmarkIcon as BookmarkIconOutline, PencilSquareIcon } from "@heroicons/react/24/outline";
 import { BookmarkIcon as BookmarkIconSolid } from "@heroicons/react/24/solid";
 import { formatDistanceToNow } from "date-fns";
 // Utility to generate background color from username and caption
@@ -296,21 +296,28 @@ export const PostCard = ({ post }) => {
       className={`${bgColor} text-white rounded-xl p-5 mb-5 shadow-sm hover:shadow-lg transition-all duration-300`}
     >
       {/* Header */}
-      <div className="flex items-center space-x-3 mb-3">
-        {avatarImage ? (
-          <img
-            src={avatarImage}
-            alt={post.author_username}
-            className="w-9 h-9 rounded-full object-cover border-2 border-white shadow"
-          />
-        ) : (
-          <div className="w-9 h-9 rounded-full flex items-center justify-center font-bold bg-white text-black shadow">
-            {initial}
-          </div>
+      <div className="flex items-center mb-3">
+        <div className="flex items-center space-x-3">
+          {avatarImage ? (
+            <img
+              src={avatarImage}
+              alt={post.author_username}
+              className="w-9 h-9 rounded-full object-cover border-2 border-white shadow"
+            />
+          ) : (
+            <div className="w-9 h-9 rounded-full flex items-center justify-center font-bold bg-white text-black shadow">
+              {initial}
+            </div>
+          )}
+          <Link to={`/user/${post.author_username}`} className="font-medium text-white text-sm hover:underline">
+            @{post.author_username}
+          </Link>
+        </div>
+        {post.author_username === loggedInUsername && (
+          <Link to={`/posts/${post.id}`} className="ml-auto">
+            <PencilSquareIcon className="w-5 h-5 text-white" />
+          </Link>
         )}
-        <Link to={`/user/${post.author_username}`} className="font-medium text-white text-sm hover:underline">
-          @{post.author_username}
-        </Link>
       </div>
 
       {/* Caption */}

--- a/frontend/src/pages/UserPosts.jsx
+++ b/frontend/src/pages/UserPosts.jsx
@@ -128,9 +128,14 @@ const UserPosts = () => {
               </p>
             )}
             {!isOwner && (
-              <button onClick={toggleFollow} className="mt-2 text-sm text-indigo-500 hover:underline">
-                {following ? 'Unfollow' : 'Follow'}
-              </button>
+              <>
+                <button onClick={toggleFollow} className="mt-2 text-sm text-indigo-500 hover:underline">
+                  {following ? 'Unfollow' : 'Follow'}
+                </button>
+                <Link to={`/chat/${username}`} className="mt-2 text-sm text-indigo-500 hover:underline">
+                  Message
+                </Link>
+              </>
             )}
             {isOwner && (
               <>


### PR DESCRIPTION
## Summary
- show pencil icon on posts you own linking to the edit page
- allow messaging a user via new Message button on their profile

## Testing
- `npm test` (fails: _TypeError: (0 , _dom.configure) is not a function_)
- `npm run lint` (fails: 93 problems)
- `cd backend && python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688dfb9c2a5083248a7412dde6933091