### PR TITLE
Add dedicated trending posts endpoint

### DIFF
--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -184,11 +184,18 @@ class AdditionalViewsTestCase(TestCase):
         Notification.objects.create(user=self.user, from_user=self.user2, notification_type="follow")
 
     def test_trending_posts(self):
-        url = reverse("posts") + "?sort=trending"
+        url = reverse("posts-trending")
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertGreaterEqual(len(resp.data["results"]), 1)
         # first post should be post2 with more likes
+        self.assertEqual(resp.data["results"][0]["id"], self.post2.id)
+
+    def test_trending_posts_old_url(self):
+        url = reverse("posts") + "?sort=trending"
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(len(resp.data["results"]), 1)
         self.assertEqual(resp.data["results"][0]["id"], self.post2.id)
 
     def test_tag_endpoints(self):

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -43,6 +43,7 @@ from .views import (
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='register'),
     path('me/', get_user_info, name='get_user_info'),
+    path('posts/trending/', TrendingPostsView.as_view(), name='posts-trending'),
     path('posts/', TrendingPostsView.as_view(), name='posts'),
     path('posts/<int:pk>/', PostDetailView.as_view(), name='post-detail'),
     path('posts/<int:post_id>/comments/', CommentListCreateView.as_view(), name='comments'),

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -163,7 +163,8 @@ class TrendingPostsView(ListCreateAPIView):
 
     def get_queryset(self):
         qs = Post.objects.all().prefetch_related("tags")
-        if self.request.query_params.get("sort") == "trending":
+        sort = self.request.query_params.get("sort")
+        if sort == "trending" or self.request.path.endswith("trending/"):
             qs = qs.annotate(like_count=Count("likes")).order_by("-like_count", "-created_at")
         else:
             qs = qs.order_by("-created_at")


### PR DESCRIPTION
## Summary
- add `/posts/trending/` endpoint with backward compatible `/posts/`
- support trending sorting without query params
- cover new endpoint in tests

## Testing
- `npm test` *(fails: Missing script "test")*
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e01fbc2b483249e717cd801222f7f