### PR TITLE
Use backend port for default WebSocket URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ npm run dev
 
 The frontend reads the backend URLs from the environment variables
 `VITE_API_BASE_URL` and `VITE_WS_BASE_URL`. If not provided, they default to
-`http://localhost:9000/api` and `ws://localhost:9000` respectively.
+`http://localhost:9000/api` and `ws://localhost:8000` respectively. Set
+`VITE_WS_BASE_URL` in your environment to override the WebSocket URL for other
+environments.
 
 The application will be available at `http://localhost:5173` by default. Build a
 production bundle with `npm run build` and preview it locally using `npm run preview`.

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,2 +1,3 @@
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:9000/api';
-export const WS_BASE_URL = import.meta.env.VITE_WS_BASE_URL || 'ws://localhost:9000';
+// Override the WebSocket URL by setting VITE_WS_BASE_URL in your environment.
+export const WS_BASE_URL = import.meta.env.VITE_WS_BASE_URL || 'ws://localhost:8000';


### PR DESCRIPTION
## Summary
- default WebSocket base URL now points to backend port 8000
- document how to override via `VITE_WS_BASE_URL`

## Testing
- `python manage.py test`
- `npm test` *(fails: TypeError: (0 , _dom.configure) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688e0a5f96f0832492e1240b94c2fafa