### PR TITLE
Derive websocket URL from API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ npm run dev
 ```
 
 The frontend reads the backend URLs from the environment variables
-`VITE_API_BASE_URL` and `VITE_WS_BASE_URL`. If not provided, they default to
-`http://localhost:9000/api` and `ws://localhost:8000` respectively. Set
-`VITE_WS_BASE_URL` in your environment to override the WebSocket URL for other
-environments.
+`VITE_API_BASE_URL` and `VITE_WS_BASE_URL`. `VITE_API_BASE_URL` defaults to
+`http://localhost:9000/api`. If `VITE_WS_BASE_URL` is not provided, the
+WebSocket URL is derived from `VITE_API_BASE_URL` by swapping the protocol to
+`ws`/`wss` and using the same host and port. In other words, both endpoints
+share the same port unless you explicitly configure `VITE_WS_BASE_URL` to point
+elsewhere.
 
 The application will be available at `http://localhost:5173` by default. Build a
 production bundle with `npm run build` and preview it locally using `npm run preview`.

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,3 +1,11 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:9000/api';
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || 'http://localhost:9000/api';
+
+// Derive the WebSocket URL from the API origin, allowing an explicit override.
+const apiUrl = new URL(API_BASE_URL);
+const wsScheme = apiUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+const derivedWsUrl = `${wsScheme}//${apiUrl.host}`;
+
 // Override the WebSocket URL by setting VITE_WS_BASE_URL in your environment.
-export const WS_BASE_URL = import.meta.env.VITE_WS_BASE_URL || 'ws://localhost:8000';
+export const WS_BASE_URL =
+  import.meta.env.VITE_WS_BASE_URL || derivedWsUrl;


### PR DESCRIPTION
## Summary
- derive WebSocket endpoint from API origin when no explicit value provided
- document that WebSocket uses same port as API unless configured otherwise

## Testing
- `npm test` (fails: TypeError: (0 , _dom.configure) is not a function)
- `npm run lint` (fails: 94 problems)


------
https://chatgpt.com/codex/tasks/task_e_688e100c07f88324bb83a5c1be767580