### PR TITLE
feat: log detailed websocket errors

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -34,14 +34,34 @@ function Navbar({ onToggleLeft, onToggleRight }) {
         }
       };
 
+      const isDev = import.meta.env.DEV;
+
+      const getMessage = (event, fallback) => {
+        if (event.code === 4401) return 'Authentication failed';
+        if (event.code === 1006) return 'Server unavailable';
+        return fallback;
+      };
+
       ws.onerror = (event) => {
-        console.error('WebSocket error', event);
-        toast.error('WebSocket error');
+        if (isDev) {
+          console.error('WebSocket error', {
+            code: event.code,
+            reason: event.reason,
+            readyState: ws.readyState
+          });
+        }
+        toast.error(getMessage(event, 'WebSocket error'));
       };
 
       ws.onclose = (event) => {
-        console.warn('WebSocket closed', event);
-        toast.warn('Disconnected from notifications');
+        if (isDev) {
+          console.warn('WebSocket closed', {
+            code: event.code,
+            reason: event.reason,
+            readyState: ws.readyState
+          });
+        }
+        toast.warn(getMessage(event, 'Disconnected from notifications'));
       };
 
       const heartbeat = setInterval(() => {


### PR DESCRIPTION
## Summary
- handle WebSocket errors and closes with descriptive messages
- log code, reason and readyState for easier debugging during development

## Testing
- `npm test` (fails: TypeError: (0 , _dom.configure) is not a function)
- `npm run lint` (fails: Unnecessary escape character in jest.config.js, many no-undef errors)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f1d5ef5a4832497a9dea2fe427665