### PR TITLE
refactor websocket auth

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -19,7 +19,7 @@ function Navbar({ onToggleLeft, onToggleRight }) {
       .then(res => setUser(res.data))
       .catch(() => setUser(null));
 
-      const ws = new WebSocket(`${WS_BASE_URL}/ws/notifications/?token=${token}`);
+      const ws = new WebSocket(`${WS_BASE_URL}/ws/notifications/`, token);
 
       ws.onmessage = (event) => {
         try {

--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -14,7 +14,7 @@ const Chat = () => {
   const connectSocket = () => {
     if (ws.current && ws.current.readyState !== WebSocket.CLOSED) return;
     const token = localStorage.getItem('access');
-    const socket = new WebSocket(`${WS_BASE_URL}/ws/chat/${username}/?token=${token}`);
+    const socket = new WebSocket(`${WS_BASE_URL}/ws/chat/${username}/`, token);
     ws.current = socket;
     socket.onmessage = (e) => {
       const msg = JSON.parse(e.data);


### PR DESCRIPTION
## Summary
- pass websocket token via header in navbar and chat
- update middleware to read JWT from websocket headers

## Testing
- `python manage.py test`
- `npm test` *(fails: TypeError: (0 , _dom.configure) is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688f1d5785108324a4e3e06c558fcd41