### PR TITLE
Handle ping messages in notification consumer

### DIFF
--- a/backend/core/consumers.py
+++ b/backend/core/consumers.py
@@ -21,6 +21,12 @@ class NotificationConsumer(AsyncJsonWebsocketConsumer):
     async def notify(self, event):
         await self.send_json(event['data'])
 
+    async def receive_json(self, content, **kwargs):
+        message_type = content.get('type')
+        if message_type == 'ping':
+            await self.send_json({'type': 'pong'})
+        # Safely ignore any other incoming messages to keep the connection open
+
 
 class ChatConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):


### PR DESCRIPTION
## Summary
- add `receive_json` to NotificationConsumer to answer `ping` messages with a `pong`
- ignore other messages to keep the connection alive

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688f1d555d588324bfd89bece5de366f