### PR TITLE
feat: use websocket subprotocol for auth token

### DIFF
--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -26,7 +26,8 @@ const Chat = () => {
       return;
     }
     const socket = new WebSocket(
-      `${WS_BASE_URL}/ws/chat/${username}/?token=${token}`,
+      `${WS_BASE_URL}/ws/chat/${username}/`,
+      token,
     );
     ws.current = socket;
     socket.onmessage = (e) => {


### PR DESCRIPTION
## Summary
- pass access token via WebSocket subprotocol instead of query string
- update JWT middleware to read token from the WebSocket subprotocol or headers

## Testing
- `npm test` (fails: Missing script: "test")
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f2300b32483249a673fd73748f000