### PR TITLE
Initialize ASGI early

### DIFF
--- a/backend/backend/asgi.py
+++ b/backend/backend/asgi.py
@@ -12,12 +12,15 @@ import os
 from django.core.asgi import get_asgi_application
 from channels.routing import ProtocolTypeRouter, URLRouter
 from core.middleware import JWTAuthMiddlewareStack
-import core.routing
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
 
+django_asgi_app = get_asgi_application()
+
+import core.routing
+
 application = ProtocolTypeRouter({
-    'http': get_asgi_application(),
+    'http': django_asgi_app,
     'websocket': JWTAuthMiddlewareStack(
         URLRouter(core.routing.websocket_urlpatterns)
     )


### PR DESCRIPTION
## Summary
- initialize `get_asgi_application` before importing `core.routing`
- use pre-initialized ASGI app in `ProtocolTypeRouter`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688f727c7d948324ba23937033b6b5ec