### PR TITLE
feat: show outgoing chat messages immediately

### DIFF
--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -16,6 +16,7 @@ const Chat = () => {
   const ws = useRef(null);
   const retryDelayRef = useRef(INITIAL_RETRY_DELAY);
   const { register, handleSubmit, reset } = useForm();
+  const currentUser = localStorage.getItem('username');
 
   const connectSocket = () => {
     if (ws.current && ws.current.readyState !== WebSocket.CLOSED) return;
@@ -100,6 +101,14 @@ const Chat = () => {
   const onSubmit = (data) => {
     if (!ws.current) return;
     if (ws.current.readyState === WebSocket.OPEN) {
+      const optimisticMessage = {
+        id: `temp-${Date.now()}`,
+        sender: currentUser || 'You',
+        recipient: username,
+        content: data.message,
+        created_at: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, optimisticMessage]);
       ws.current.send(JSON.stringify({ message: data.message }));
       reset();
     } else {


### PR DESCRIPTION
## Summary
- optimistically append outgoing chat messages and reset input
- track current user for optimistic messages

## Testing
- `npm test` *(fails: TypeError: (0 , _dom.configure) is not a function)*
- `npm run lint` *(fails: 95 problems (85 errors, 10 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688f7d265da48324b2f84f3726a46016